### PR TITLE
feat: Use reflect to convert struct to Prometheus metrics

### DIFF
--- a/cmd/command/daemon/run.go
+++ b/cmd/command/daemon/run.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/scitix/sichek/metrics"
 	"github.com/scitix/sichek/pkg/systemd"
 	"github.com/scitix/sichek/service"
 )
@@ -93,7 +92,6 @@ func NewDaemonRunCmd() *cobra.Command {
 			serviceChan := make(chan service.Service, 1)
 
 			logrus.WithField("daemon", "run").Info("starting sichek daemon service")
-			go metrics.InitPrometheus()
 			done := service.HandleSignals(cancel, signals, serviceChan)
 			signal.Notify(signals, service.AllowedSignals...)
 			daemonService, err := service.NewService(ctx, cfgFile, specFile, usedComponents, ignoredComponents, annoKey)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,11 +21,13 @@ import (
 
 	"github.com/scitix/sichek/cmd/command"
 	"github.com/scitix/sichek/cmd/command/component"
+	"github.com/scitix/sichek/metrics"
 	"github.com/scitix/sichek/pkg/utils"
 )
 
 func main() {
 	rootCmd := command.NewRootCmd()
+	go metrics.InitPrometheus()
 	if err := rootCmd.Execute(); err != nil {
 		panic(err)
 	}

--- a/components/cpu/metrics/metrics.go
+++ b/components/cpu/metrics/metrics.go
@@ -26,9 +26,9 @@ func NewCpuMetrics() *CpuMetrics {
 
 func (m *CpuMetrics) ExportMetrics(metrics *collector.CPUOutput) {
 	// cpu_arch_info
-	m.CpuGaugeWithStr.ExportStructWithStrField(metrics.CPUArchInfo, []string{""}, TagPrefix)
+	m.CpuGaugeWithStr.ExportStructWithStrField(metrics.CPUArchInfo, []string{}, TagPrefix)
 	// cpu_usage_info
 	m.CpuUsageGauge.ExportStruct(metrics.UsageInfo, nil, TagPrefix)
 	// host_info
-	m.CpuGaugeWithStr.ExportStructWithStrField(metrics.HostInfo, []string{""}, TagPrefix)
+	m.CpuGaugeWithStr.ExportStructWithStrField(metrics.HostInfo, []string{}, TagPrefix)
 }

--- a/components/cpu/metrics/metrics.go
+++ b/components/cpu/metrics/metrics.go
@@ -1,55 +1,34 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scitix/sichek/components/cpu/collector"
+	common "github.com/scitix/sichek/metrics"
 )
 
-var (
-	cpuGaugeMetrics = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "cpu_gauge_metrics",
-		},
-		[]string{"component_name", "metric_name"},
-	)
-	cpuGaugeMetricsWithValues = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "cpu_gauge_metrics_with_values",
-		},
-		[]string{"component_name", "metric_name", "value"},
-	)
+const (
+	MetricPrefix = "sichek_cpu"
+	TagPrefix    = "json"
 )
 
-func InitCpuMetrics() {
-	prometheus.MustRegister(cpuGaugeMetrics)
-	prometheus.MustRegister(cpuGaugeMetricsWithValues)
+type CpuMetrics struct {
+	CpuUsageGauge   *common.GaugeVecMetricExporter
+	CpuGaugeWithStr *common.GaugeVecMetricExporter
 }
 
-func ExportCPUMetrics(metrics *collector.CPUOutput) {
+func NewCpuMetrics() *CpuMetrics {
+	CpuUsageGauge := common.NewGaugeVecMetricExporter(MetricPrefix, nil)
+	CpuGaugeWithStr := common.NewGaugeVecMetricExporter(MetricPrefix, []string{"str_metrics"})
+	return &CpuMetrics{
+		CpuUsageGauge:   CpuUsageGauge,
+		CpuGaugeWithStr: CpuGaugeWithStr,
+	}
+}
+
+func (m *CpuMetrics) ExportMetrics(metrics *collector.CPUOutput) {
 	// cpu_arch_info
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "architecture", metrics.CPUArchInfo.Architecture).Set(1)
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "model_name", metrics.CPUArchInfo.ModelName).Set(1)
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "vendor_id", metrics.CPUArchInfo.VendorID).Set(1)
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "family", metrics.CPUArchInfo.Family).Set(1)
-	cpuGaugeMetrics.WithLabelValues("cpu", "socket").Set(float64(metrics.CPUArchInfo.Sockets))
-	cpuGaugeMetrics.WithLabelValues("cpu", "cores_per_socket").Set(float64(metrics.CPUArchInfo.CoresPerSocket))
-	cpuGaugeMetrics.WithLabelValues("cpu", "threads_per_core").Set(float64(metrics.CPUArchInfo.ThreadPerCore))
-	cpuGaugeMetrics.WithLabelValues("cpu", "numa_num").Set(float64(metrics.CPUArchInfo.NumaNum))
-
+	m.CpuGaugeWithStr.ExportStructWithStrField(metrics.CPUArchInfo, []string{""}, TagPrefix)
 	// cpu_usage_info
-	cpuGaugeMetrics.WithLabelValues("cpu", "runnable_task_count").Set(float64(metrics.UsageInfo.RunnableTaskCount))
-	cpuGaugeMetrics.WithLabelValues("cpu", "total_thread_count").Set(float64(metrics.UsageInfo.TotalThreadCount))
-	cpuGaugeMetrics.WithLabelValues("cpu", "usage_time").Set(float64(metrics.UsageInfo.CPUUsageTime))
-	cpuGaugeMetrics.WithLabelValues("cpu", "cpu_load_avg1m").Set(float64(metrics.UsageInfo.CpuLoadAvg1m))
-	cpuGaugeMetrics.WithLabelValues("cpu", "cpu_load_avg5m").Set(float64(metrics.UsageInfo.CpuLoadAvg5m))
-	cpuGaugeMetrics.WithLabelValues("cpu", "cpu_load_avg15m").Set(float64(metrics.UsageInfo.CpuLoadAvg15m))
-	cpuGaugeMetrics.WithLabelValues("cpu", "system_processes_total").Set(float64(metrics.UsageInfo.SystemProcessesTotal))
-	cpuGaugeMetrics.WithLabelValues("cpu", "system_procs_running").Set(float64(metrics.UsageInfo.SystemProcsRunning))
-	cpuGaugeMetrics.WithLabelValues("cpu", "system_procs_blocked").Set(float64(metrics.UsageInfo.SystemProcsBlocked))
-	cpuGaugeMetrics.WithLabelValues("cpu", "system_interrupts_total").Set(float64(metrics.UsageInfo.SystemInterruptsTotal))
-
+	m.CpuUsageGauge.ExportStruct(metrics.UsageInfo, nil, TagPrefix)
 	// host_info
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "hostname", metrics.HostInfo.Hostname).Set(1)
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "os_version", metrics.HostInfo.OSVersion).Set(1)
-	cpuGaugeMetricsWithValues.WithLabelValues("cpu", "kernel_version", metrics.HostInfo.KernelVersion).Set(1)
+	m.CpuGaugeWithStr.ExportStructWithStrField(metrics.HostInfo, []string{""}, TagPrefix)
 }

--- a/components/ethernet/ethernet.go
+++ b/components/ethernet/ethernet.go
@@ -56,11 +56,11 @@ type component struct {
 	cacheSize   int64
 
 	service *common.CommonService
+	metrics *metrics.EthernetMetrics
 }
 
 func NewEthernetComponent(cfgFile string) (comp common.Component, err error) {
 	ethernetComponentOnce.Do(func() {
-		metrics.InitEthernetMetrics()
 		ethernetComponent, err = newEthernetComponent(cfgFile)
 		if err != nil {
 			panic(err)
@@ -120,6 +120,7 @@ func newEthernetComponent(cfgFile string) (comp *component, err error) {
 		cacheInfo:   make([]common.Info, cfg.Ethernet.CacheSize),
 		currIndex:   0,
 		cacheSize:   cfg.Ethernet.CacheSize,
+		metrics:     metrics.NewEthernetMetrics(),
 	}
 	component.service = common.NewCommonService(ctx, cfg, component.HealthCheck)
 	return component, nil
@@ -137,7 +138,8 @@ func (c *component) HealthCheck(ctx context.Context) (*common.Result, error) {
 	if !ok {
 		return nil, fmt.Errorf("expected c.info to be of type *collector.EthernetInfo, got %T", c.info)
 	}
-	metrics.ExportEthernetMetrics(ethernetInfo)
+	// fmt.Println(ethernetInfo)
+	c.metrics.ExportMetrics(ethernetInfo)
 	status := consts.StatusNormal
 	checkerResults := make([]*common.CheckerResult, 0)
 	var err error

--- a/components/ethernet/metrics/metrics.go
+++ b/components/ethernet/metrics/metrics.go
@@ -1,26 +1,33 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scitix/sichek/components/ethernet/collector"
+	common "github.com/scitix/sichek/metrics"
 )
 
-var (
-	ethernetGaugeMetrics = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "ethernet_gauge_metrics",
-		},
-		[]string{"component_name", "metric_name", "dev_name", "phy_state"},
-	)
+const (
+	MetricPrefix = "sichek_ethernet"
+	TagPrefix    = "json"
 )
 
-func InitEthernetMetrics() {
-	prometheus.MustRegister(ethernetGaugeMetrics)
+type EthernetMetrics struct {
+	EthernetDevGauge          *common.GaugeVecMetricExporter
+	EthernetHardWareInfoGauge *common.GaugeVecMetricExporter
 }
 
-func ExportEthernetMetrics(ethernetInfo *collector.EthernetInfo) {
-	// eth_hardware_info
-	for _, eth := range ethernetInfo.EthHardWareInfo {
-		ethernetGaugeMetrics.WithLabelValues("ethernet", "hardware_info", eth.EthDev, eth.PhyState).Set(1)
+func NewEthernetMetrics() *EthernetMetrics {
+	EthernetDevGauge := common.NewGaugeVecMetricExporter(MetricPrefix, []string{"device_name"})
+	EthernetHardWareInfoGauge := common.NewGaugeVecMetricExporter(MetricPrefix, []string{"eth_dev", "phy_stat"})
+	return &EthernetMetrics{
+		EthernetDevGauge:          EthernetDevGauge,
+		EthernetHardWareInfoGauge: EthernetHardWareInfoGauge,
+	}
+}
+func (m *EthernetMetrics) ExportMetrics(metrics *collector.EthernetInfo) {
+	for _, device := range metrics.EthDevs {
+		m.EthernetDevGauge.SetMetric("eth_dev", []string{device}, float64(1.0))
+	}
+	for _, hardWareInfo := range metrics.EthHardWareInfo {
+		m.EthernetHardWareInfoGauge.SetMetric("eth_dev", []string{hardWareInfo.EthDev, hardWareInfo.PhyState}, float64(1.0))
 	}
 }

--- a/components/hang/collector/getter.go
+++ b/components/hang/collector/getter.go
@@ -18,8 +18,6 @@ package collector
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/scitix/sichek/components/common"
@@ -159,13 +157,11 @@ func (c *HangGetter) Collect(ctx context.Context) (common.Info, error) {
 				case "txpci":
 					infoValue = int64(deviceInfo.PCIeInfo.PCIeTx / 1024)
 				case "smclk":
-					smClkInt := strings.Split(deviceInfo.Clock.CurSMClk, " ")[0]
-					smClk, _ := strconv.Atoi(smClkInt)
-					infoValue = int64(smClk)
+					smClkInt := deviceInfo.Clock.CurSMClk
+					infoValue = int64(smClkInt)
 				case "gclk":
-					gClkInt := strings.Split(deviceInfo.Clock.CurGraphicsClk, " ")[0]
-					gClk, _ := strconv.Atoi(gClkInt)
-					infoValue = int64(gClk)
+					gClkInt := deviceInfo.Clock.CurGraphicsClk
+					infoValue = int64(gClkInt)
 				default:
 					logrus.WithField("collector", "hanggetter").Errorf("failed to get info of %s", c.items[j])
 				}

--- a/components/memory/metrics/metrics.go
+++ b/components/memory/metrics/metrics.go
@@ -1,30 +1,26 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scitix/sichek/components/memory/collector"
+	common "github.com/scitix/sichek/metrics"
 )
 
-var (
-	memoryGaugeMetrics = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "memory_gauge_metrics",
-		},
-		[]string{"component_name", "metric_name"},
-	)
+const (
+	MetricPrefix = "sichek_memory"
+	TagPrefix    = "json"
 )
 
-func InitMemoryMetrics() {
-	prometheus.MustRegister(memoryGaugeMetrics)
+type MemoryMetrics struct {
+	MemoryGauge *common.GaugeVecMetricExporter
 }
 
-func ExportMemoryMetrics(metrics *collector.MemoryInfo) {
-	memoryGaugeMetrics.WithLabelValues("memory", "mem_total").Set(float64(metrics.MemTotal))
-	memoryGaugeMetrics.WithLabelValues("memory", "mem_used").Set(float64(metrics.MemUsed))
-	memoryGaugeMetrics.WithLabelValues("memory", "mem_free").Set(float64(metrics.MemFree))
-	memoryGaugeMetrics.WithLabelValues("memory", "mem_percent_used").Set(float64(metrics.MemPercentUsed))
-	memoryGaugeMetrics.WithLabelValues("memory", "mem_anonymous_used").Set(float64(metrics.MemAnonymousUsed))
-	memoryGaugeMetrics.WithLabelValues("memory", "pagecache_used").Set(float64(metrics.PageCacheUsed))
-	memoryGaugeMetrics.WithLabelValues("memory", "mem_unevictable_used").Set(float64(metrics.MemUnevictableUsed))
-	memoryGaugeMetrics.WithLabelValues("memory", "dirty_page_used").Set(float64(metrics.DirtyPageUsed))
+func NewMemoryMetrics() *MemoryMetrics {
+	MemoryGauge := common.NewGaugeVecMetricExporter(MetricPrefix, nil)
+	return &MemoryMetrics{
+		MemoryGauge: MemoryGauge,
+	}
+}
+
+func (m *MemoryMetrics) ExportMetrics(metrics *collector.MemoryInfo) {
+	m.MemoryGauge.ExportStructWithStrField(metrics, nil, TagPrefix)
 }

--- a/components/memory/metrics/metrics.go
+++ b/components/memory/metrics/metrics.go
@@ -22,5 +22,5 @@ func NewMemoryMetrics() *MemoryMetrics {
 }
 
 func (m *MemoryMetrics) ExportMetrics(metrics *collector.MemoryInfo) {
-	m.MemoryGauge.ExportStructWithStrField(metrics, nil, TagPrefix)
+	m.MemoryGauge.ExportStruct(metrics, nil, TagPrefix)
 }

--- a/components/nvidia/checker/check_app_clocks.go
+++ b/components/nvidia/checker/check_app_clocks.go
@@ -61,7 +61,7 @@ func (c *AppClocksChecker) Check(ctx context.Context, data any) (*common.Checker
 				gpusAppClocksStatus = make(map[int]string)
 			}
 			gpusAppClocksStatus[device.Index] = fmt.Sprintf(
-				"GPU %d:%s AppSMClk: %s, MaxAppSMClk: %s, AppGraphicsClk: %s, MaxGraphicsClk: %s, AppMemoryClk: %s, MaxMemoryClk: %s\n",
+				"GPU %d:%s AppSMClk: %d Mhz, MaxAppSMClk: %d Mhz, AppGraphicsClk: %d Mhz, MaxGraphicsClk: %d Mhz, AppMemoryClk: %d Mhz, MaxMemoryClk: %d Mhz\n",
 				device.Index, device.UUID,
 				device.Clock.AppSMClk,
 				device.Clock.MaxSMClk,

--- a/components/nvidia/collector/clock_info.go
+++ b/components/nvidia/collector/clock_info.go
@@ -25,15 +25,15 @@ import (
 )
 
 type ClockInfo struct {
-	CurGraphicsClk string `json:"cur_graphics_clk"`
-	AppGraphicsClk string `json:"app_graphics_clk"`
-	MaxGraphicsClk string `json:"max_graphics_clk"`
-	CurMemoryClk   string `json:"cur_memory_clk"`
-	AppMemoryClk   string `json:"app_memory_clk"`
-	MaxMemoryClk   string `json:"max_memory_clk"`
-	CurSMClk       string `json:"cur_sm_clk"`
-	AppSMClk       string `json:"app_sm_clk"`
-	MaxSMClk       string `json:"max_sm_clk"`
+	CurGraphicsClk uint32 `json:"cur_graphics_clk"`
+	AppGraphicsClk uint32 `json:"app_graphics_clk"`
+	MaxGraphicsClk uint32 `json:"max_graphics_clk"`
+	CurMemoryClk   uint32 `json:"cur_memory_clk"`
+	AppMemoryClk   uint32 `json:"app_memory_clk"`
+	MaxMemoryClk   uint32 `json:"max_memory_clk"`
+	CurSMClk       uint32 `json:"cur_sm_clk"`
+	AppSMClk       uint32 `json:"app_sm_clk"`
+	MaxSMClk       uint32 `json:"max_sm_clk"`
 }
 
 func (clk *ClockInfo) JSON() ([]byte, error) {
@@ -62,65 +62,59 @@ func (clk *ClockInfo) Get(device nvml.Device, uuid string) error {
 }
 
 func (clk *ClockInfo) getGraphicsClocks(device nvml.Device, uuid string) error {
-	curGraphicsClk, err := device.GetClockInfo(nvml.CLOCK_GRAPHICS)
+	var err nvml.Return
+	clk.CurGraphicsClk, err = device.GetClockInfo(nvml.CLOCK_GRAPHICS)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get current graphics clock for GPU %v: %v", uuid, err)
 	}
-	clk.CurGraphicsClk = fmt.Sprintf("%d MHz", curGraphicsClk)
 
-	graphicsClkSet, err := device.GetApplicationsClock(nvml.CLOCK_GRAPHICS)
+	clk.AppGraphicsClk, err = device.GetApplicationsClock(nvml.CLOCK_GRAPHICS)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get application graphics clock setting for GPU %v: %v", uuid, err)
 	}
-	clk.AppGraphicsClk = fmt.Sprintf("%d MHz", graphicsClkSet)
 
-	maxGraphicsClk, err := device.GetMaxClockInfo(nvml.CLOCK_GRAPHICS)
+	clk.MaxGraphicsClk, err = device.GetMaxClockInfo(nvml.CLOCK_GRAPHICS)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get max graphics clock for GPU %v: %v", uuid, err)
 	}
-	clk.MaxGraphicsClk = fmt.Sprintf("%d MHz", maxGraphicsClk)
 
 	return nil
 }
 
 func (clk *ClockInfo) getMemoryClocks(device nvml.Device, uuid string) error {
-	curMemClock, err := device.GetClockInfo(nvml.CLOCK_MEM)
+	var err nvml.Return
+	clk.CurMemoryClk, err = device.GetClockInfo(nvml.CLOCK_MEM)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get current memory clock for GPU %v: %v", uuid, err)
 	}
-	clk.CurMemoryClk = fmt.Sprintf("%d MHz", curMemClock)
 
-	memClockSet, err := device.GetApplicationsClock(nvml.CLOCK_MEM)
+	clk.AppMemoryClk, err = device.GetApplicationsClock(nvml.CLOCK_MEM)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get application memory clock setting for GPU %v: %v", uuid, err)
 	}
-	clk.AppMemoryClk = fmt.Sprintf("%d MHz", memClockSet)
 
-	maxMemClock, err := device.GetMaxClockInfo(nvml.CLOCK_MEM)
+	clk.MaxMemoryClk, err = device.GetMaxClockInfo(nvml.CLOCK_MEM)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get max memory clock for GPU %v: %v", uuid, err)
 	}
-	clk.MaxMemoryClk = fmt.Sprintf("%d MHz", maxMemClock)
 	return nil
 }
 
 func (clk *ClockInfo) getSMClocks(device nvml.Device, uuid string) error {
-	curSMClock, err := device.GetClockInfo(nvml.CLOCK_SM)
+	var err nvml.Return
+	clk.CurSMClk, err = device.GetClockInfo(nvml.CLOCK_SM)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get current SM clock for GPU %v: %v", uuid, err)
 	}
-	clk.CurSMClk = fmt.Sprintf("%d MHz", curSMClock)
 
-	smClockSet, err := device.GetApplicationsClock(nvml.CLOCK_SM)
+	clk.AppSMClk, err = device.GetApplicationsClock(nvml.CLOCK_SM)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get application SM clock setting for GPU %v: %v", uuid, err)
 	}
-	clk.AppSMClk = fmt.Sprintf("%d MHz", smClockSet)
 
-	maxSMClock, err := device.GetMaxClockInfo(nvml.CLOCK_SM)
+	clk.MaxSMClk, err = device.GetMaxClockInfo(nvml.CLOCK_SM)
 	if !errors.Is(err, nvml.SUCCESS) {
 		return fmt.Errorf("failed to get max SM clock for GPU %v: %v", uuid, err)
 	}
-	clk.MaxSMClk = fmt.Sprintf("%d MHz", maxSMClock)
 	return nil
 }

--- a/components/nvidia/collector/memory_errors.go
+++ b/components/nvidia/collector/memory_errors.go
@@ -62,13 +62,13 @@ type LocationErrors struct {
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1g9bcbee49054a953d333d4aa11e8b9c25
 	// L1Cache          ErrorType `json:"GPU L1 Cache"`
 	// L2Cache          ErrorType `json:"GPU L2 Cache"`
-	DRAM ErrorType `json:"Turing+ DRAM"`
+	DRAM ErrorType `json:"Turing+DRAM"`
 	// GPUDeviceMemory  ErrorType `json:"GPU Device Memory"`
 	// GPURegisterFile  ErrorType `json:"GPU Register File"`
 	// GPUTextureMemory ErrorType `json:"GPU Texture Memory"`
 	// SharedMemory     ErrorType `json:"Shared memory"`
 	// CBU              ErrorType `json:"CBU"`
-	SRAM ErrorType `json:"Turing+ SRAM"`
+	SRAM ErrorType `json:"Turing+SRAM"`
 }
 
 type ErrorType struct {

--- a/components/nvidia/collector/nvlink_state.go
+++ b/components/nvidia/collector/nvlink_state.go
@@ -30,8 +30,6 @@ type NVLinkState struct {
 	NVlinkSupported      bool `json:"nvlink_supported"`
 	FeatureEnabled       bool `json:"feature_enabled"`
 	LinkNo               int  `json:"link_no"`
-	ThroughputRawRxBytes int  `json:"throughput_raw_rx_bytes"`
-	ThroughputRawTxBytes int  `json:"throughput_raw_tx_bytes"`
 }
 
 type NVLinkStates struct {

--- a/components/nvidia/collector/states_info.go
+++ b/components/nvidia/collector/states_info.go
@@ -25,7 +25,7 @@ import (
 )
 
 type StatesInfo struct {
-	GpuPersistenceM string `json:"persistence"`
+	GpuPersistenceM string `json:"persistencem"`
 	// TODO
 	// GpuRstState     string `json:"gpu_reset_required"`
 	GpuPstate uint32 `json:"pstate"`

--- a/components/nvidia/metrics/common.go
+++ b/components/nvidia/metrics/common.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+type GaugeVecMetricExporter struct {
+	prefix     string
+	labelKeys  []string
+	metricsMap map[string]*prometheus.GaugeVec
+	lock       sync.Mutex
+}
+
+func NewGaugeVecMetricExporter(prefix string, labelKeys []string) *GaugeVecMetricExporter {
+	return &GaugeVecMetricExporter{
+		prefix:     prefix,
+		labelKeys:  labelKeys,
+		metricsMap: make(map[string]*prometheus.GaugeVec),
+	}
+}
+
+// ExportStruct This method receives a struct (or a nested struct) and a list of label values. It converts the struct into a map of metrics, then registers and sets values for each metric.
+func (e *GaugeVecMetricExporter) ExportStruct(v interface{}, labelVals []string, tagPrefix string) {
+	metricsValueMap := make(map[string]float64)
+	StructToMetricsMap(reflect.ValueOf(v), "", tagPrefix, metricsValueMap)
+
+	for name, val := range metricsValueMap {
+		fullName := sanitizeMetricName(e.prefix + "_" + name)
+		e.SetMetric(fullName, labelVals, val)
+	}
+}
+
+// setMetric set metric value to a metric name with a list of label values.
+func (e *GaugeVecMetricExporter) SetMetric(name string, labelVals []string, value float64) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	// Check if the metric already exists, if not create and register it
+	gaugeVec, exists := e.metricsMap[name]
+	if !exists {
+		gaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: name,
+		}, e.labelKeys)
+		// Register the new metric with Prometheus
+		prometheus.MustRegister(gaugeVec)
+		// Store it in the metricsMap
+		e.metricsMap[name] = gaugeVec
+	}
+	// Set the metric value for the metric
+	gaugeVec.WithLabelValues(labelVals...).Set(value)
+}
+
+// StructToMetricsMap This recursively flattens the struct into a map where each field is represented by a string path and its corresponding value.
+func StructToMetricsMap(v reflect.Value, path, tagPrefix string, metrics map[string]float64) {
+	// Dereference pointers
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldType := t.Field(i)
+			if !field.CanInterface() {
+				continue
+			}
+			// 指定从结构体字段的tagPrefix(通常使用"json")标签中提取标签的值作为字段名。如果没有标签，则使用字段的名称
+			tag := fieldType.Tag.Get(tagPrefix)
+			if tag == "-" {
+				continue
+			}
+			fieldName := tag
+			if fieldName == "" {
+				fieldName = fieldType.Name
+			}
+			// Construct the new path for nested fields
+			newPath := path
+			if newPath != "" {
+				newPath += "_"
+			}
+			newPath += fieldName
+			// Recursively call StructToMetricsMap for nested fields
+			StructToMetricsMap(field, newPath, tagPrefix, metrics)
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			strKey := fmt.Sprintf("%v", key.Interface())
+			StructToMetricsMap(v.MapIndex(key), path+"_"+strKey, tagPrefix, metrics)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			StructToMetricsMap(v.Index(i), fmt.Sprintf("%s_%d", path, i), tagPrefix, metrics)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		metrics[path] = float64(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		metrics[path] = float64(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		metrics[path] = v.Float()
+	case reflect.Bool:
+		if v.Bool() {
+			metrics[path] = 1.0
+		} else {
+			metrics[path] = 0.0
+		}
+	case reflect.String:
+		if v.String() == "enable" || v.String() == "true" {
+			metrics[path] = 1.0
+		} else {
+			metrics[path] = 0.0
+		}
+	default:
+		logrus.WithField("metrics", "common").Errorf("Unsupported type %v to reflect", v.Type())
+	}
+}
+
+// sanitizeMetricName This function sanitizes metric names to ensure they are valid for Prometheus by replacing non-alphanumeric characters (except _).
+func sanitizeMetricName(name string) string {
+	name = strings.ToLower(name)
+	// Replace non-alphanumeric characters with "_"
+	name = strings.ReplaceAll(name, ".", "_")
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, "+", "_")
+	name = strings.ReplaceAll(name, " ", "_")
+	name = strings.ReplaceAll(name, "[", "_")
+	name = strings.ReplaceAll(name, "]", "")
+	return name
+}
+
+func BoolToFloat64(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
+}

--- a/components/nvidia/metrics/common_test.go
+++ b/components/nvidia/metrics/common_test.go
@@ -1,0 +1,173 @@
+package metrics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewGaugeVecMetricExporter(t *testing.T) {
+	prefix := "test_prefix"
+	labelKeys := []string{"label1", "label2"}
+	exporter := NewGaugeVecMetricExporter(prefix, labelKeys)
+
+	if exporter.prefix != prefix {
+		t.Errorf("expected prefix %s, got %s", prefix, exporter.prefix)
+	}
+	if !reflect.DeepEqual(exporter.labelKeys, labelKeys) {
+		t.Errorf("expected labelKeys %v, got %v", labelKeys, exporter.labelKeys)
+	}
+	if len(exporter.metricsMap) != 0 {
+		t.Errorf("expected empty metricsMap, got %v", exporter.metricsMap)
+	}
+}
+
+func TestGaugeVecMetricExporter_SetMetric(t *testing.T) {
+	exporter := NewGaugeVecMetricExporter("test", []string{"label1"})
+	exporter.SetMetric("test_metric", []string{"value1"}, 42.0)
+
+	if _, exists := exporter.metricsMap["test_metric"]; !exists {
+		t.Fatalf("expected metric test_metric to exist")
+	}
+}
+
+func TestGaugeVecMetricExporter_ExportStruct(t *testing.T) {
+	type TestStruct struct {
+		Field1 int     `json:"field1"`
+		Field2 float64 `json:"field2"`
+		Field3 bool    `json:"field3"`
+	}
+
+	exporter := NewGaugeVecMetricExporter("test", []string{"label1"})
+	testStruct := TestStruct{Field1: 10, Field2: 20.5, Field3: true}
+	exporter.ExportStruct(testStruct, []string{"value1"}, "json")
+
+	expectedMetrics := map[string]float64{
+		"test_field1": 10.0,
+		"test_field2": 20.5,
+		"test_field3": 1.0,
+	}
+
+	for name := range expectedMetrics {
+		if _, exists := exporter.metricsMap[name]; !exists {
+			t.Fatalf("expected metric %s to exist", name)
+		}
+	}
+}
+
+func TestSliceStructToMetricsMap(t *testing.T) {
+	type NestedStruct struct {
+		InnerField1 int `json:"inner_field0"`
+		InnerField2 int `json:"inner_field1"`
+	}
+	type TestStruct struct {
+		Field []NestedStruct `json:"field"`
+	}
+
+	exporter := NewGaugeVecMetricExporter("test", []string{"label1"})
+	testStruct := TestStruct{
+		Field: []NestedStruct{
+			{InnerField1: 100, InnerField2: 200},
+			{InnerField1: 300, InnerField2: 400},
+		},
+	}
+	exporter.ExportStruct(testStruct, []string{"value1"}, "json")
+	for name := range exporter.metricsMap {
+		t.Logf("Metric name: %s", name)
+	}
+	expectedMetrics := map[string]float64{
+		"test_field_0_inner_field0": 100,
+		"test_field_0_inner_field1": 200,
+		"test_field_1_inner_field0": 300,
+		"test_field_1_inner_field1": 400,
+	}
+
+	for name := range expectedMetrics {
+		if _, exists := exporter.metricsMap[name]; !exists {
+			t.Fatalf("expected metric %s to exist", name)
+		}
+	}
+}
+
+func TestMapStructToMetricsMap(t *testing.T) {
+	type NestedStruct struct {
+		InnerField1 int `json:"inner_field0"`
+		InnerField2 int `json:"inner_field1"`
+	}
+	type TestStruct struct {
+		Field map[string]NestedStruct `json:"field"`
+	}
+
+	exporter := NewGaugeVecMetricExporter("test", []string{"label1"})
+	testStruct := TestStruct{
+		Field: map[string]NestedStruct{
+			"field0": {InnerField1: 100, InnerField2: 200},
+			"field1": {InnerField1: 300, InnerField2: 400},
+		},
+	}
+	exporter.ExportStruct(testStruct, []string{"value1"}, "json")
+	for name := range exporter.metricsMap {
+		t.Logf("Metric name: %s", name)
+	}
+	expectedMetrics := map[string]float64{
+		"test_field_field0_inner_field0": 100,
+		"test_field_field0_inner_field1": 200,
+		"test_field_field1_inner_field0": 300,
+		"test_field_field1_inner_field1": 400,
+	}
+
+	for name := range expectedMetrics {
+		if _, exists := exporter.metricsMap[name]; !exists {
+			t.Fatalf("expected metric %s to exist", name)
+		}
+	}
+}
+
+func TestStructToMetricsMap(t *testing.T) {
+	type NestedStruct struct {
+		InnerField1 int `json:"inner_field1"`
+		InnerField2 int `json:"inner_field2"`
+	}
+	type TestStruct struct {
+		Field1 int          `json:"field1"`
+		Field2 NestedStruct `json:"field2"`
+	}
+
+	testStruct := TestStruct{
+		Field1: 42,
+		Field2: NestedStruct{InnerField1: 100, InnerField2: 200},
+	}
+
+	metrics := make(map[string]float64)
+	StructToMetricsMap(reflect.ValueOf(testStruct), "", "json", metrics)
+
+	expectedMetrics := map[string]float64{
+		"field1":              42.0,
+		"field2_inner_field1": 100.0,
+		"field2_inner_field2": 200.0,
+	}
+
+	for key, expectedValue := range expectedMetrics {
+		if metrics[key] != expectedValue {
+			t.Errorf("expected metric %s to have value %v, got %v", key, expectedValue, metrics[key])
+		}
+	}
+}
+
+func TestSanitizeMetricName(t *testing.T) {
+	tests := map[string]string{
+		"metric.name":     "metric_name",
+		"metric-name":     "metric_name",
+		"metric+name":     "metric_name",
+		"metric[name]":    "metric_name",
+		"metric name":     "metric_name",
+		"MetricName":      "metricname",
+		"metric[complex]": "metric_complex",
+	}
+
+	for input, expected := range tests {
+		output := sanitizeMetricName(input)
+		if output != expected {
+			t.Errorf("expected sanitized name %s, got %s", expected, output)
+		}
+	}
+}

--- a/components/nvidia/metrics/metrics.go
+++ b/components/nvidia/metrics/metrics.go
@@ -41,7 +41,7 @@ func (m *NvidiaMetrics) ExportMetrics(metrics *collector.NvidiaInfo) {
 	// DeviceCount
 	m.NvidiaDevCntGauge.SetMetric("device_count", nil, float64(metrics.DeviceCount))
 	// SoftwareInfo
-	m.NvidiaSoftwareInfoGauge.ExportStructWithStrField(metrics.SoftwareInfo, []string{""}, TagPrefix)
+	m.NvidiaSoftwareInfoGauge.ExportStructWithStrField(metrics.SoftwareInfo, []string{}, TagPrefix)
 
 	for _, device := range metrics.DevicesInfo {
 		deviceIdx := fmt.Sprintf("%d", device.Index)

--- a/components/nvidia/metrics/metrics.go
+++ b/components/nvidia/metrics/metrics.go
@@ -1,87 +1,68 @@
 package metrics
 
 import (
-	"strconv"
+	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scitix/sichek/components/nvidia/collector"
-	"github.com/scitix/sichek/pkg/utils"
 )
 
-var (
-	NvidiaGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "nvidia_metrics",
-		},
-		[]string{"component_name", "metric_name"},
-	)
-	NvidiaValueGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "nvidia_value_metrics",
-		},
-		[]string{"component_name", "metric_name", "value"},
-	)
-	NvidiaDeviceGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "nvidia_device_metrics",
-		},
-		[]string{"component_name", "device_index", "metric_name"},
-	)
-	NvidiaNVLinkGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "nvidia_nvlink_metrics",
-		},
-		[]string{"component_name", "device_index", "link_no", "metric_name"},
-	)
-)
-
-func InitNvidiaMetrics() {
-	prometheus.MustRegister(NvidiaGauge)
-	prometheus.MustRegister(NvidiaValueGauge)
-	prometheus.MustRegister(NvidiaNVLinkGauge)
+type NvidiaMetrics struct {
+	NvidiaDevCntGauge         *GaugeVecMetricExporter
+	NvidiaDrvVerionGauge      *GaugeVecMetricExporter
+	NvidiaCudaVerionGauge     *GaugeVecMetricExporter
+	NvidiaDevUUIDGauge        *GaugeVecMetricExporter
+	NvidiaDeviceGauge         *GaugeVecMetricExporter
+	NvidiaDeviceClkEventGauge *GaugeVecMetricExporter
 }
 
-func ExportNvidiaMetrics(metrics *collector.NvidiaInfo) {
-	NvidiaGauge.WithLabelValues("nvidia", "device_count").Set(float64(metrics.DeviceCount))
-	NvidiaValueGauge.WithLabelValues("nvidia", "driver_version", metrics.SoftwareInfo.DriverVersion).Set(1)
-	NvidiaValueGauge.WithLabelValues("nvidia", "cuda_version", metrics.SoftwareInfo.CUDAVersion).Set(1)
-	for _, device := range metrics.DevicesInfo {
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "pci_gen").Set(float64(device.PCIeInfo.PCILinkGen))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "pci_gen_max").Set(float64(device.PCIeInfo.PCILinkGenMAX))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "pci_width").Set(float64(device.PCIeInfo.PCILinkWidth))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "pci_width_max").Set(float64(device.PCIeInfo.PCILinkWidthMAX))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "pci_tx").Set(float64(device.PCIeInfo.PCIeTx))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "pci_rx").Set(float64(device.PCIeInfo.PCIeRx))
-
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "power_usage").Set(float64(device.Power.PowerUsage))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "seted_power_limit_W").Set(float64(device.Power.CurPowerLimit))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "default_power_limit_W").Set(float64(device.Power.DefaultPowerLimit))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "enforced_power_limit_W").Set(float64(device.Power.EnforcedPowerLimit))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "min_power_limit_W").Set(float64(device.Power.MinPowerLimit))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "max_power_limit_W").Set(float64(device.Power.MaxPowerLimit))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "power_violations").Set(float64(device.Power.PowerViolations))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "thermal_violations").Set(float64(device.Power.ThermalViolations))
-
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "current_temperature_C").Set(float64(device.Temperature.GPUCurTemperature))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "threadhold_temperature_C").Set(float64(device.Temperature.GPUThresholdTemperature))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "threadhold_temperature_shutdown_C").Set(float64(device.Temperature.GPUThresholdTemperatureShutdown))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "threadhold_temperature_slowdown_C").Set(float64(device.Temperature.GPUThresholdTemperatureSlowdown))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "current_memory_temperature_C").Set(float64(device.Temperature.MemoryCurTemperature))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "max_memory_operation_temperature_C").Set(float64(device.Temperature.MemoryMaxOperationLimitTemperature))
-
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "gpu_usage_percent").Set(float64(device.Utilization.GPUUsagePercent))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "gpu_memory_usage_percent").Set(float64(device.Utilization.MemoryUsagePercent))
-
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "nvlink_supported").Set(utils.ParseBoolToFloat(device.NVLinkStates.NVlinkSupported))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "all_feature_enabled").Set(utils.ParseBoolToFloat(device.NVLinkStates.AllFeatureEnabled))
-		NvidiaDeviceGauge.WithLabelValues("nvidia", device.UUID, "active_nvlink_num").Set(float64(device.NVLinkStates.NvlinkNum))
-		for _, nvlinkState := range device.NVLinkStates.NVLinkStates {
-			NvidiaNVLinkGauge.WithLabelValues("nvidia", device.UUID, strconv.Itoa(nvlinkState.LinkNo), "nvlink_supported").Set(utils.ParseBoolToFloat(nvlinkState.NVlinkSupported))
-			NvidiaNVLinkGauge.WithLabelValues("nvidia", device.UUID, strconv.Itoa(nvlinkState.LinkNo), "feature_enabled").Set(utils.ParseBoolToFloat(nvlinkState.FeatureEnabled))
-			NvidiaNVLinkGauge.WithLabelValues("nvidia", device.UUID, strconv.Itoa(nvlinkState.LinkNo), "throughput_raw_rx_bytes").Set(float64(nvlinkState.ThroughputRawRxBytes))
-			NvidiaNVLinkGauge.WithLabelValues("nvidia", device.UUID, strconv.Itoa(nvlinkState.LinkNo), "throughput_raw_tx_bytes").Set(float64(nvlinkState.ThroughputRawTxBytes))
-		}
-
+func NewNvidiaMetrics() *NvidiaMetrics {
+	NvidiaDevCntGauge := NewGaugeVecMetricExporter("sichek_nvidia", nil)
+	NvidiaDrvVersionGauge := NewGaugeVecMetricExporter("sichek_nvidia", []string{"driver_version"})
+	NvidiaCudaVersionGauge := NewGaugeVecMetricExporter("sichek_nvidia", []string{"cuda_version"})
+	NvidiaDevUUIDGauge := NewGaugeVecMetricExporter("sichek_nvidia", []string{"index", "uuid"})
+	NvidiaDeviceGauge := NewGaugeVecMetricExporter("sichek_nvidia", []string{"index"})
+	NvidiaDeviceClkEventGauge := NewGaugeVecMetricExporter("sichek_nvidia", []string{"index", "clock_event_reason_id", "description"})
+	return &NvidiaMetrics{
+		NvidiaDevCntGauge:         NvidiaDevCntGauge,
+		NvidiaDrvVerionGauge:      NvidiaDrvVersionGauge,
+		NvidiaCudaVerionGauge:     NvidiaCudaVersionGauge,
+		NvidiaDevUUIDGauge:        NvidiaDevUUIDGauge,
+		NvidiaDeviceGauge:         NvidiaDeviceGauge,
+		NvidiaDeviceClkEventGauge: NvidiaDeviceClkEventGauge,
 	}
+}
 
+func (m *NvidiaMetrics) ExportMetrics(metrics *collector.NvidiaInfo) {
+	m.NvidiaDevCntGauge.SetMetric("device_count", nil, float64(metrics.DeviceCount))
+	m.NvidiaDrvVerionGauge.SetMetric("driver_version", []string{metrics.SoftwareInfo.DriverVersion}, 1)
+	m.NvidiaCudaVerionGauge.SetMetric("cuda_version", []string{metrics.SoftwareInfo.CUDAVersion}, 1)
+	for _, device := range metrics.DevicesInfo {
+		m.NvidiaDeviceGauge.ExportStruct(device.PCIeInfo, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.States, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.Clock, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.Power, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.Temperature, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.Utilization, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.NVLinkStates, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		if device.ClockEvents.IsSupported {
+			m.NvidiaDrvVerionGauge.SetMetric("gpu_idle", []string{fmt.Sprintf("%d", device.Index)}, BoolToFloat64(device.ClockEvents.GpuIdle))
+			currentClkEvent := make(map[string]struct{})
+			for _, event := range device.ClockEvents.CriticalClockEvents {
+				currentClkEvent[event.Name] = struct{}{}
+				m.NvidiaDeviceClkEventGauge.SetMetric(event.Name, []string{fmt.Sprintf("%d", device.Index), fmt.Sprintf("%d", event.ClockEventReasonId), event.Description}, float64(1.0))
+			}
+			for _, event := range device.ClockEvents.CriticalClockEvents {
+				currentClkEvent[event.Name] = struct{}{}
+				m.NvidiaDeviceClkEventGauge.SetMetric(event.Name, []string{fmt.Sprintf("%d", device.Index), fmt.Sprintf("%d", event.ClockEventReasonId), event.Description}, float64(1.0))
+			}
+			for eventName := range m.NvidiaDeviceClkEventGauge.metricsMap {
+				if _, found := currentClkEvent[eventName]; !found {
+					m.NvidiaDeviceClkEventGauge.SetMetric(eventName, []string{fmt.Sprintf("%d", device.Index), "0", "0"}, float64(0.0))
+				}
+			}
+		}
+		m.NvidiaDeviceGauge.ExportStruct(device.MemoryErrors.RemappedRows, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.MemoryErrors.VolatileECC, []string{fmt.Sprintf("%d", device.Index)}, "json")
+		m.NvidiaDeviceGauge.ExportStruct(device.MemoryErrors.AggregateECC, []string{fmt.Sprintf("%d", device.Index)}, "json")
+	}
 }

--- a/components/nvidia/nvidia.go
+++ b/components/nvidia/nvidia.go
@@ -56,6 +56,8 @@ type component struct {
 	serviceMtx    sync.RWMutex
 	running       bool
 	resultChannel chan *common.Result
+
+	metrics *metrics.NvidiaMetrics
 }
 
 var (
@@ -137,7 +139,6 @@ func GetComponent() common.Component {
 
 func NewComponent(cfgFile string, specFile string, ignoredCheckers []string) (comp common.Component, err error) {
 	nvidiaComponentOnce.Do(func() {
-		metrics.InitNvidiaMetrics()
 		nvidiaComponent, err = newNvidia(cfgFile, specFile, ignoredCheckers)
 	})
 	return nvidiaComponent, err
@@ -189,6 +190,8 @@ func newNvidia(cfgFile string, specFile string, ignoredCheckers []string) (comp 
 		return nil, err
 	}
 
+	metrics := metrics.NewNvidiaMetrics()
+
 	component := &component{
 		name:          consts.ComponentNameNvidia,
 		ctx:           ctx,
@@ -206,6 +209,7 @@ func newNvidia(cfgFile string, specFile string, ignoredCheckers []string) (comp 
 		xidPoller:     xidPoller,
 		running:       false,
 		resultChannel: resultChannel,
+		metrics:       metrics,
 	}
 
 	return component, nil
@@ -224,7 +228,7 @@ func (c *component) HealthCheck(ctx context.Context) (*common.Result, error) {
 		logrus.WithField("component", "NVIDIA").Errorf("failed to collect nvidia info: %v", err)
 		return nil, err
 	}
-	metrics.ExportNvidiaMetrics(nvidiaInfo)
+	c.metrics.ExportMetrics(nvidiaInfo)
 	status := consts.StatusNormal
 	level := consts.LevelInfo
 	checkerResults := make([]*common.CheckerResult, 0)

--- a/components/nvidia/nvidia.go
+++ b/components/nvidia/nvidia.go
@@ -145,13 +145,12 @@ func NewComponent(cfgFile string, specFile string, ignoredCheckers []string) (co
 }
 
 func newNvidia(cfgFile string, specFile string, ignoredCheckers []string) (comp *component, err error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer func() {
 		if err != nil {
 			cancel()
 		}
 	}()
-
 	nvmlInst, err := NewNvml(ctx)
 	if err != nil {
 		logrus.WithField("component", "NVIDIA").Errorf("NewNvidia create nvml failed: %v", err)

--- a/metrics/common_test.go
+++ b/metrics/common_test.go
@@ -16,8 +16,8 @@ func TestNewGaugeVecMetricExporter(t *testing.T) {
 	if !reflect.DeepEqual(exporter.labelKeys, labelKeys) {
 		t.Errorf("expected labelKeys %v, got %v", labelKeys, exporter.labelKeys)
 	}
-	if len(exporter.metricsMap) != 0 {
-		t.Errorf("expected empty metricsMap, got %v", exporter.metricsMap)
+	if len(exporter.MetricsMap) != 0 {
+		t.Errorf("expected empty MetricsMap, got %v", exporter.MetricsMap)
 	}
 }
 
@@ -25,7 +25,7 @@ func TestGaugeVecMetricExporter_SetMetric(t *testing.T) {
 	exporter := NewGaugeVecMetricExporter("test", []string{"label1"})
 	exporter.SetMetric("test_metric", []string{"value1"}, 42.0)
 
-	if _, exists := exporter.metricsMap["test_metric"]; !exists {
+	if _, exists := exporter.MetricsMap["test_metric"]; !exists {
 		t.Fatalf("expected metric test_metric to exist")
 	}
 }
@@ -48,7 +48,7 @@ func TestGaugeVecMetricExporter_ExportStruct(t *testing.T) {
 	}
 
 	for name := range expectedMetrics {
-		if _, exists := exporter.metricsMap[name]; !exists {
+		if _, exists := exporter.MetricsMap[name]; !exists {
 			t.Fatalf("expected metric %s to exist", name)
 		}
 	}
@@ -71,7 +71,7 @@ func TestSliceStructToMetricsMap(t *testing.T) {
 		},
 	}
 	exporter.ExportStruct(testStruct, []string{"value1"}, "json")
-	for name := range exporter.metricsMap {
+	for name := range exporter.MetricsMap {
 		t.Logf("Metric name: %s", name)
 	}
 	expectedMetrics := map[string]float64{
@@ -82,7 +82,7 @@ func TestSliceStructToMetricsMap(t *testing.T) {
 	}
 
 	for name := range expectedMetrics {
-		if _, exists := exporter.metricsMap[name]; !exists {
+		if _, exists := exporter.MetricsMap[name]; !exists {
 			t.Fatalf("expected metric %s to exist", name)
 		}
 	}
@@ -105,7 +105,7 @@ func TestMapStructToMetricsMap(t *testing.T) {
 		},
 	}
 	exporter.ExportStruct(testStruct, []string{"value1"}, "json")
-	for name := range exporter.metricsMap {
+	for name := range exporter.MetricsMap {
 		t.Logf("Metric name: %s", name)
 	}
 	expectedMetrics := map[string]float64{
@@ -116,7 +116,7 @@ func TestMapStructToMetricsMap(t *testing.T) {
 	}
 
 	for name := range expectedMetrics {
-		if _, exists := exporter.metricsMap[name]; !exists {
+		if _, exists := exporter.MetricsMap[name]; !exists {
 			t.Fatalf("expected metric %s to exist", name)
 		}
 	}
@@ -137,7 +137,7 @@ func TestStructToMetricsMap(t *testing.T) {
 		Field2: NestedStruct{InnerField1: 100, InnerField2: 200},
 	}
 
-	metrics := make(map[string]float64)
+	metrics := make(map[string]*StructMetrics)
 	StructToMetricsMap(reflect.ValueOf(testStruct), "", "json", metrics)
 
 	expectedMetrics := map[string]float64{
@@ -147,7 +147,7 @@ func TestStructToMetricsMap(t *testing.T) {
 	}
 
 	for key, expectedValue := range expectedMetrics {
-		if metrics[key] != expectedValue {
+		if metrics[key].MetricsValue != expectedValue {
 			t.Errorf("expected metric %s to have value %v, got %v", key, expectedValue, metrics[key])
 		}
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -7,14 +7,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/scitix/sichek/components/common"
+	"github.com/scitix/sichek/consts"
 )
 
 var (
-	CheckerResultsCounterMetrics = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	CheckerResultsCounterMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "sichek_results_counter_metrics",
 		},
-		[]string{"component_name", "node_name", "status", "level", "error_name", "device"},
+		[]string{"component_name", "node_name", "error_name", "device"},
 	)
 )
 
@@ -24,7 +25,11 @@ func InitCheckerResultsMetrics() {
 
 func ExportCheckerResultsMetrics(metrics *common.Result) {
 	for _, checker := range metrics.Checkers {
-		CheckerResultsCounterMetrics.WithLabelValues(metrics.Item, metrics.Node, metrics.Status, metrics.Level, checker.ErrorName, checker.Device).Inc()
+		if checker.Status == consts.StatusAbnormal {
+			CheckerResultsCounterMetrics.WithLabelValues(metrics.Item, metrics.Node, checker.ErrorName, checker.Device).Set(1.0)
+		} else {
+			CheckerResultsCounterMetrics.WithLabelValues(metrics.Item, metrics.Node, checker.ErrorName, checker.Device).Set(0.0)
+		}
 	}
 }
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -4,37 +4,38 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/scitix/sichek/components/common"
 	"github.com/scitix/sichek/consts"
 )
 
-var (
-	CheckerResultsCounterMetrics = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "sichek_results_counter_metrics",
-		},
-		[]string{"component_name", "node_name", "error_name", "device"},
-	)
+const (
+	MetricPrefix = "sichek"
+	TagPrefix    = "json"
 )
 
-func InitCheckerResultsMetrics() {
-	prometheus.MustRegister(CheckerResultsCounterMetrics)
+type HealthCheckResMetrics struct {
+	HealthCheckResGauge *GaugeVecMetricExporter
 }
 
-func ExportCheckerResultsMetrics(metrics *common.Result) {
+func NewHealthCheckResMetrics() *HealthCheckResMetrics {
+	HealthCheckResGauge := NewGaugeVecMetricExporter(MetricPrefix, []string{"component_name", "level", "error_name", "device"})
+	return &HealthCheckResMetrics{
+		HealthCheckResGauge: HealthCheckResGauge,
+	}
+}
+
+func (m *HealthCheckResMetrics) ExportMetrics(metrics *common.Result) {
 	for _, checker := range metrics.Checkers {
 		if checker.Status == consts.StatusAbnormal {
-			CheckerResultsCounterMetrics.WithLabelValues(metrics.Item, metrics.Node, checker.ErrorName, checker.Device).Set(1.0)
+			m.HealthCheckResGauge.SetMetric("healthcheck_results", []string{metrics.Item, checker.Level, checker.ErrorName, checker.Device}, 1.0)
 		} else {
-			CheckerResultsCounterMetrics.WithLabelValues(metrics.Item, metrics.Node, checker.ErrorName, checker.Device).Set(0.0)
+			m.HealthCheckResGauge.SetMetric("healthcheck_results", []string{metrics.Item, checker.Level, checker.ErrorName, checker.Device}, 0.0)
 		}
 	}
 }
 
 func InitPrometheus() {
-	InitCheckerResultsMetrics()
 	// 启动 Prometheus HTTP 处理程序
 	http.Handle("/metrics", promhttp.Handler())
 	if err := http.ListenAndServe(":9091", nil); err != nil {


### PR DESCRIPTION
- Use the reflect package to recursively traverse structs and automatically map struct fields to metric names and float64 type values.
- Supports nested structs, slices, maps, and field name mapping based on tags.
- Converts metric names and float64 type values to Prometheus metric data dynamically