### PR TITLE
fix: refine dmesg error detection logic and enable dmesg module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO := go
 INSTALL_DIR := /usr/sbin
 VERSION_MAJOR := 0
 VERSION_MINOR := 3
-VERSION_PATCH := 0
+VERSION_PATCH := 1
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GO_VERSION := $(shell $(GO) version | cut -d ' ' -f 3)
 BUILD_TIME := $(shell date -u '+%Y-%m-%d')
@@ -22,6 +22,11 @@ all:
 debug:
 	mkdir -p build/bin/
 	GOOS=linux GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -gcflags "all=-N -l" -o build/bin/$(PROJECT_NAME) cmd/main.go
+	VERSION_MAJOR=${VERSION_MAJOR} VERSION_MINOR=${VERSION_MINOR} VERSION_PATCH=${VERSION_PATCH} \
+	GIT_COMMIT=${GIT_COMMIT} GO_VERSION=${GO_VERSION} BUILD_TIME=${BUILD_TIME} \
+	goreleaser release --snapshot --clean
+	curl -X PUT "https://oss-ap-southeast.scitix.ai/scitix-release/sichek/vdebug/sichek_vdebug_linux_amd64.rpm" --upload-file ./dist/sichek_${VERSION}_linux_amd64.rpm
+	curl -X PUT "https://oss-ap-southeast.scitix.ai/scitix-release/sichek/vdebug/sichek_vdebug_linux_amd64.deb" --upload-file ./dist/sichek_${VERSION}_linux_amd64.deb
 
 docker:
 	docker build \

--- a/components/dmesg/checker/checker.go
+++ b/components/dmesg/checker/checker.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/scitix/sichek/components/common"
@@ -71,15 +72,16 @@ func (c *DmesgChecker) Check(ctx context.Context, data any) (*common.CheckerResu
 
 	status := consts.StatusNormal
 	var suggest string
-	var raw string
+	var raw strings.Builder
 	if len(info.Name) != 0 {
 		status = consts.StatusAbnormal
 		suggest = "check dmesg error"
 		for i, log := range info.Raw {
-			raw = raw + fmt.Sprintf("name: %s, detail: %s\n", info.Name[i], log)
+			raw.WriteString(fmt.Sprintf("name: %s, detail: %s\n", info.Name[i], log))
 			logrus.Errorf("Detected dmesg error: %s", log)
 		}
 	}
+
 	return &common.CheckerResult{
 		Name:        c.name,
 		Description: "Get errors from dmesg",
@@ -89,7 +91,7 @@ func (c *DmesgChecker) Check(ctx context.Context, data any) (*common.CheckerResu
 		Status:      status,
 		Level:       consts.LevelCritical,
 		Suggestion:  suggest,
-		Detail:      raw,
+		Detail:      raw.String(),
 		ErrorName:   consts.ErrorNameDmesg,
 	}, nil
 }

--- a/components/dmesg/checker/checker.go
+++ b/components/dmesg/checker/checker.go
@@ -25,7 +25,6 @@ import (
 	"github.com/scitix/sichek/components/common"
 	"github.com/scitix/sichek/components/dmesg/config"
 	"github.com/scitix/sichek/consts"
-	"github.com/scitix/sichek/pkg/utils"
 
 	"github.com/sirupsen/logrus"
 )
@@ -70,18 +69,16 @@ func (c *DmesgChecker) Check(ctx context.Context, data any) (*common.CheckerResu
 		return nil, fmt.Errorf("wrong input of DmesgChecker")
 	}
 
-	var raw string
-	js, err := utils.JSON(info)
-	if err != nil {
-		logrus.WithError(err).Error("failed to get info")
-	}
-	raw = raw + js + "\n"
-
 	status := consts.StatusNormal
 	var suggest string
+	var raw string
 	if len(info.Name) != 0 {
 		status = consts.StatusAbnormal
 		suggest = "check dmesg error"
+		for i, log := range info.Raw {
+			raw = raw + fmt.Sprintf("name: %s, detail: %s\n", info.Name[i], log)
+			logrus.Errorf("Detected dmesg error: %s", log)
+		}
 	}
 	return &common.CheckerResult{
 		Name:        c.name,

--- a/components/dmesg/config/default_user_config.yaml
+++ b/components/dmesg/config/default_user_config.yaml
@@ -1,45 +1,25 @@
 dmesg:
   name: DMesg
-  FileNmae: ["/var/log/dmesg"]
-  Cmd:
-    - ["dmesg"]
+  FileNmae: ["/var/log/kern.log"]
+  # Cmd:
+  #   - ["dmesg"]
   query_interval: 30
   cache_size: 5
   checkers:
-    OOM1:
-      name: "oom"
-      description: "oom error in dmesg"
-      regexp: '(?i)\b(invoked|triggered) oom-killer\b'
-      level: error
-    OOM2:
-      name: "oom"
-      description: "oom error in dmesg"
-      regexp: 'oom-kill:constraint='
-      level: error
-    OOM3:
-      name: "oom"
+    OOM:
+      name: "sys_oom"
       description: "oom error in dmesg"
       regexp: 'Out of memory:'
       level: error
-    OOM4:
-      name: "oom"
+    CgroupOOM:
+      name: "cgroup_oom"
       description: "oom error in dmesg"
       regexp: 'Memory cgroup out of memory'
       level: error
-    NVXID:
-      name: "nvidia"
-      description: "nv xid error in dmesg"
-      regexp: 'NVRM: Xid.*?: (\d+),'
-      level: error
     NVSXID:
-      name: "nvidia"
+      name: "nvidia_sxid"
       description: "nv sxid error in dmesg"
       regexp: 'SXid.*?: (\d+),'
-      level: error
-    PEERMEM:
-      name: "peermem"
-      description: "peermem invalid context error in dmesg"
-      regexp: '.*ERROR detected invalid context, skipping further processing'
       level: error
     NCCL:
       name: "nccl"

--- a/components/dmesg/dmesg.go
+++ b/components/dmesg/dmesg.go
@@ -227,7 +227,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 		return checkAllPassed
 	}
 	for n := range dmesgEvent {
-		fmt.Printf("\tDetected %s Event\n", n)
+		fmt.Printf("\tDetected %d Kernel Events:\n %s\n", len(dmesgEvent), dmesgEvent[n])
 	}
 	return checkAllPassed
 }

--- a/components/infiniband/infiniband.go
+++ b/components/infiniband/infiniband.go
@@ -118,7 +118,7 @@ func newInfinibandComponent(cfgFile string, specFile string, ignoredCheckers []s
 		cacheInfo:     make([]common.Info, cfg.Infiniband.CacheSize),
 		currIndex:     0,
 		cacheSize:     cfg.Infiniband.CacheSize,
-		metrics:     metrics.NewInfinibandMetrics(),
+		metrics:       metrics.NewInfinibandMetrics(),
 	}
 	// step4: start the service
 	component.service = common.NewCommonService(ctx, cfg, component.componentName, component.GetTimeout(), component.HealthCheck)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -81,7 +81,7 @@ var (
 	DefaultComponentQueryInterval = time.Duration.Seconds(1)
 
 	DefaultComponents = []string{
-		ComponentNameCPU, ComponentNameNvidia, ComponentNameInfiniband, ComponentNameGpfs, // ComponentNameDmesg,
+		ComponentNameCPU, ComponentNameNvidia, ComponentNameInfiniband, ComponentNameGpfs, ComponentNameDmesg,
 		ComponentNameNCCL, ComponentNameHang,
 	}
 )

--- a/pkg/utils/filter/filter.go
+++ b/pkg/utils/filter/filter.go
@@ -20,7 +20,7 @@ type Filter struct {
 }
 
 func NewFilter(regexpName []string, regexps []string, filesName []string, cmds [][]string, cacheLineN int64) (*Filter, error) {
-	return NewFilterSkip(regexpName, regexps, filesName, cmds, cacheLineN, 100)
+	return NewFilterSkip(regexpName, regexps, filesName, cmds, cacheLineN, 99)
 }
 
 func NewFilterSkip(regexpName []string, regexps []string, filesName []string, cmds [][]string, cacheLineN int64, skipPercent int64) (*Filter, error) {


### PR DESCRIPTION
- Corrected log source from /var/log/dmesg to /var/log/kern.log for error event detection
- Removed redundant regex patterns for matching error events
- Removed error detection via  `dmesg` command
- Enabled the dmesg module for diagnostics