### PR TITLE
fixed a logic error in pkg/utils.PrintTitle where a negative padding l…

### DIFF
--- a/pkg/utils/print_title.go
+++ b/pkg/utils/print_title.go
@@ -40,13 +40,21 @@ func PrintTitle(text, paddingChar string) {
 
 	textLength := len(text)
 	paddingLength := width - textLength
-	if paddingLength < 0 {
+	if paddingLength <= 0 {
 		fmt.Println(text)
+		return
 	}
+
+	charLen := len(paddingChar)
+	if charLen == 0 {
+		fmt.Println(text)
+		return
+	}
+
 	leftPadding := paddingLength / 2
 	rightPadding := paddingLength - leftPadding
 
-	left := strings.Repeat(paddingChar, leftPadding/len(paddingChar)) + paddingChar[:leftPadding%len(paddingChar)]
-	right := strings.Repeat(paddingChar, rightPadding/len(paddingChar)) + paddingChar[:rightPadding%len(paddingChar)]
+	left := strings.Repeat(paddingChar, leftPadding/charLen) + paddingChar[:leftPadding%charLen]
+	right := strings.Repeat(paddingChar, rightPadding/charLen) + paddingChar[:rightPadding%charLen]
 	fmt.Println(left + text + right)
 }

--- a/pkg/utils/print_title_test.go
+++ b/pkg/utils/print_title_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestPrintTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		text        string
+		paddingChar string
+	}{
+		{
+			name:        "Normal case",
+			text:        "hello",
+			paddingChar: "-",
+		},
+		{
+			name:        "Narrow terminal",
+			text:        "this is a very long text that exceeds terminal width",
+			paddingChar: "=",
+		},
+		{
+			name:        "Empty padding char",
+			text:        "test",
+			paddingChar: "",
+		},
+		{
+			name:        "Multi-byte text",
+			text:        "你好世界",
+			paddingChar: "*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We mainly want to ensure it doesn't panic
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("PrintTitle panicked: %v", r)
+				}
+			}()
+			PrintTitle(tt.text, tt.paddingChar)
+		})
+	}
+}


### PR DESCRIPTION
…ength could be calculated if the terminal width was smaller than the text length. This resulted in a negative repeat count in strings.Repeat. The fix adds explicit bounds checking and handles narrow terminal or non-TTY environments gracefully by returning early if padding is not possible.