### PR TITLE
fix(infiniband): skip spec-based IBLost check when spec.IBPFDevs is e…

### DIFF
--- a/components/infiniband/checker/ib_lost.go
+++ b/components/infiniband/checker/ib_lost.go
@@ -77,7 +77,7 @@ func (c *IBLostChecker) Check(ctx context.Context, data any) (*common.CheckerRes
 		}).Errorf("IBLost: HCAPCINum != IBCapablePCINum")
 		result.Status = consts.StatusAbnormal
 		result.Detail = fmt.Sprintf("IBLost: HCAPCINum != IBCapablePCINum(%d != %d)", infinibandInfo.HCAPCINum, infinibandInfo.IBCapablePCINum)
-	} else if nodeEffectiveHCANum != c.spec.HCANum && infinibandInfo.HCAPCINum%2 == 1 && infinibandInfo.HCAPCINum != 1 {
+	} else if len(c.spec.IBPFDevs) > 0 && nodeEffectiveHCANum != c.spec.HCANum && infinibandInfo.HCAPCINum%2 == 1 && infinibandInfo.HCAPCINum != 1 {
 		logrus.WithFields(logrus.Fields{
 			"checker":   c.Name(),
 			"effective": nodeEffectiveHCANum,


### PR DESCRIPTION
…mpty

When TrimMapByList removes all entries from spec.IBPFDevs (e.g. OSS spec has wrong device names that don't match current hardware), spec.HCANum retains its pre-trim stale value. The second condition in IBLostChecker then compares actual device count against this stale value, causing a false positive IBLost critical alert alongside SpecEmptyError.

Add a len(c.spec.IBPFDevs) > 0 guard so the spec-based comparison is skipped when the spec is known to be empty. The first condition (HCAPCINum != IBCapablePCINum) still runs as a pure hardware cross-check.