### PR TITLE
fix(transceiver): concurrent collect and BDF dedup for RoCE environments

### DIFF
--- a/components/transceiver/collector/transceiver_info.go
+++ b/components/transceiver/collector/transceiver_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 )
@@ -18,10 +19,10 @@ func (t *TransceiverInfo) JSON() (string, error) {
 }
 
 type ModuleInfo struct {
-	Interface    string `json:"interface"`
-	IBDev        string `json:"ib_dev"`
-	NetworkType  string `json:"network_type"`
-	CollectTool  string `json:"collect_tool"`
+	Interface   string `json:"interface"`
+	IBDev       string `json:"ib_dev"`
+	NetworkType string `json:"network_type"`
+	CollectTool string `json:"collect_tool"`
 
 	Present      bool   `json:"present"`
 	ModuleType   string `json:"module_type"`
@@ -48,6 +49,18 @@ type ModuleInfo struct {
 	LinkErrors map[string]uint64 `json:"link_errors"`
 }
 
+type collectTask struct {
+	iface      InterfaceEntry
+	useMLXLink bool
+	dev        string // IBDev name, PCIe BDF, or interface name
+}
+
+type indexedModule struct {
+	idx    int
+	module ModuleInfo
+	iface  InterfaceEntry
+}
+
 type TransceiverCollector struct {
 	networkClassifier *NetworkClassifier
 }
@@ -66,66 +79,109 @@ func (c *TransceiverCollector) Collect(ctx context.Context) (*TransceiverInfo, e
 		return nil, fmt.Errorf("enumerate interfaces failed: %w", err)
 	}
 
-	info := &TransceiverInfo{}
-	seen := make(map[string]bool) // deduplicate by interface name
+	// Build the deduplicated task list: IB entries take priority over Ethernet entries
+	// for the same interface name (mlxlink via IBDev gives richer data).
+	// BDF-based deduplication prevents collecting VF-rep interfaces that share
+	// the same physical PCIe function as their parent PF.
+	seenName := make(map[string]bool)
+	seenBDF := make(map[string]bool)
+	var tasks []collectTask
 
-	// IB interfaces first (they have richer data via mlxlink)
 	for _, iface := range interfaces {
 		if !iface.IsIB {
 			continue
 		}
 		if iface.Name != "" {
-			seen[iface.Name] = true
+			seenName[iface.Name] = true
 		}
-		module, collectErr := CollectMLXLink(ctx, iface.IBDev)
-		if collectErr != nil {
-			logrus.WithField("component", "transceiver").Debugf("skip IB %s: %v", iface.IBDev, collectErr)
-			continue
+		if iface.PcieBDF != "" {
+			seenBDF[iface.PcieBDF] = true
 		}
-		module.Interface = iface.Name
-		module.IBDev = iface.IBDev
-		module.CollectTool = "mlxlink"
-		speedStr, speedMbps := GetLinkSpeed(iface.Name)
-		module.LinkSpeed = speedStr
-		module.NetworkType = c.networkClassifier.Classify(iface.Name, speedMbps)
-		info.Modules = append(info.Modules, module)
+		tasks = append(tasks, collectTask{iface: iface, useMLXLink: true, dev: iface.IBDev})
 	}
 
-	// Then ethernet interfaces (skip if already collected via IB)
 	for _, iface := range interfaces {
-		if iface.IsIB {
+		if iface.IsIB || seenName[iface.Name] {
 			continue
 		}
-		if seen[iface.Name] {
+		if iface.PcieBDF != "" && seenBDF[iface.PcieBDF] {
+			logrus.WithField("component", "transceiver").Debugf("skip %s: same BDF %s as IB interface", iface.Name, iface.PcieBDF)
 			continue
 		}
-
-		var module ModuleInfo
-		var collectErr error
-
-		// mlx5 ethernet ports: use mlxlink with PCIe BDF (ethtool -m gives hex dump)
 		if iface.IsMLX5 && iface.PcieBDF != "" {
-			module, collectErr = CollectMLXLink(ctx, iface.PcieBDF)
-			if collectErr != nil {
-				logrus.WithField("component", "transceiver").Debugf("skip mlx5 %s (BDF %s): %v", iface.Name, iface.PcieBDF, collectErr)
-				continue
-			}
-			module.CollectTool = "mlxlink"
+			tasks = append(tasks, collectTask{iface: iface, useMLXLink: true, dev: iface.PcieBDF})
 		} else {
-			module, collectErr = CollectEthtool(ctx, iface.Name)
-			if collectErr != nil {
-				logrus.WithField("component", "transceiver").Debugf("skip %s: no transceiver module detected (%v)", iface.Name, collectErr)
-				continue
-			}
-			module.CollectTool = "ethtool"
+			tasks = append(tasks, collectTask{iface: iface, useMLXLink: false, dev: iface.Name})
 		}
+	}
 
-		module.Interface = iface.Name
-		speedStr, speedMbps := GetLinkSpeed(iface.Name)
+	// Collect all interfaces concurrently to avoid sequential mlxlink timeouts.
+	resultCh := make(chan indexedModule, len(tasks))
+	var wg sync.WaitGroup
+
+	for i, task := range tasks {
+		wg.Add(1)
+		go func(i int, task collectTask) {
+			defer wg.Done()
+
+			var module ModuleInfo
+			var collectErr error
+
+			if task.useMLXLink {
+				module, collectErr = CollectMLXLink(ctx, task.dev)
+				if collectErr != nil {
+					if task.iface.IsIB {
+						logrus.WithField("component", "transceiver").Debugf("skip IB %s: %v", task.dev, collectErr)
+					} else {
+						logrus.WithField("component", "transceiver").Debugf("skip mlx5 %s (BDF %s): %v", task.iface.Name, task.dev, collectErr)
+					}
+					return
+				}
+				module.CollectTool = "mlxlink"
+			} else {
+				module, collectErr = CollectEthtool(ctx, task.dev)
+				if collectErr != nil {
+					logrus.WithField("component", "transceiver").Debugf("skip %s: no transceiver module detected (%v)", task.iface.Name, collectErr)
+					return
+				}
+				module.CollectTool = "ethtool"
+			}
+
+			module.Interface = task.iface.Name
+			if task.iface.IsIB {
+				module.IBDev = task.iface.IBDev
+			}
+
+			resultCh <- indexedModule{idx: i, module: module, iface: task.iface}
+		}(i, task)
+	}
+
+	wg.Wait()
+	close(resultCh)
+
+	// Preserve original order (IB before Ethernet, as tasks were ordered).
+	ordered := make([]indexedModule, 0, len(tasks))
+	for r := range resultCh {
+		ordered = append(ordered, r)
+	}
+	sortByIndex(ordered)
+
+	info := &TransceiverInfo{}
+	for _, r := range ordered {
+		module := r.module
+		speedStr, speedMbps := GetLinkSpeed(r.iface.Name)
 		module.LinkSpeed = speedStr
-		module.NetworkType = c.networkClassifier.Classify(iface.Name, speedMbps)
+		module.NetworkType = c.networkClassifier.Classify(r.iface.Name, speedMbps)
 		info.Modules = append(info.Modules, module)
 	}
 
 	return info, nil
+}
+
+func sortByIndex(items []indexedModule) {
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && items[j].idx < items[j-1].idx; j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
 }

--- a/components/transceiver/collector/transceiver_info.go
+++ b/components/transceiver/collector/transceiver_info.go
@@ -115,14 +115,20 @@ func (c *TransceiverCollector) Collect(ctx context.Context) (*TransceiverInfo, e
 		}
 	}
 
-	// Collect all interfaces concurrently to avoid sequential mlxlink timeouts.
+	// Collect interfaces concurrently with a bounded worker pool.
+	// Unlimited parallelism causes PCIe device lock contention across 40+ mlxlink
+	// processes, which serializes them anyway and wastes the 30s command timeout.
+	const maxWorkers = 8
 	resultCh := make(chan indexedModule, len(tasks))
+	sem := make(chan struct{}, maxWorkers)
 	var wg sync.WaitGroup
 
 	for i, task := range tasks {
 		wg.Add(1)
 		go func(i int, task collectTask) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 
 			var module ModuleInfo
 			var collectErr error

--- a/components/transceiver/collector/utils.go
+++ b/components/transceiver/collector/utils.go
@@ -42,6 +42,12 @@ func EnumerateTransceiverInterfaces() ([]InterfaceEntry, error) {
 		if _, err := os.Stat(devicePath); os.IsNotExist(err) {
 			continue
 		}
+		// Skip SR-IOV Virtual Functions — physfn exists only on VFs, not PFs.
+		// mlxlink on VF BDFs fails slowly (8-11s), wasting the collection budget.
+		physfnPath := filepath.Join(netDir, name, "device", "physfn")
+		if _, err := os.Stat(physfnPath); err == nil {
+			continue
+		}
 		// Detect mlx5 driver — these need mlxlink instead of ethtool for DOM
 		entry := InterfaceEntry{Name: name, IsIB: false}
 		driverLink := filepath.Join(netDir, name, "device", "driver")

--- a/components/transceiver/collector/utils.go
+++ b/components/transceiver/collector/utils.go
@@ -79,10 +79,20 @@ func EnumerateTransceiverInterfaces() ([]InterfaceEntry, error) {
 		netDevDir := filepath.Join(ibDir, ibDev, "device", "net")
 		netDevs, _ := os.ReadDir(netDevDir)
 		netDevName := ""
+		var netBDF string
 		if len(netDevs) > 0 {
 			netDevName = netDevs[0].Name()
+			ueventPath := filepath.Join(netDir, netDevName, "device", "uevent")
+			if data, err := os.ReadFile(ueventPath); err == nil {
+				for _, line := range strings.Split(string(data), "\n") {
+					if strings.HasPrefix(line, "PCI_SLOT_NAME=") {
+						netBDF = strings.TrimPrefix(line, "PCI_SLOT_NAME=")
+						break
+					}
+				}
+			}
 		}
-		entries = append(entries, InterfaceEntry{Name: netDevName, IsIB: true, IBDev: ibDev})
+		entries = append(entries, InterfaceEntry{Name: netDevName, IsIB: true, IBDev: ibDev, PcieBDF: netBDF})
 	}
 
 	return entries, nil


### PR DESCRIPTION
In RoCE environments with multi-port NICs (e.g. 8x NICs x 4 ports), the sequential mlxlink collection timed out before completing, resulting in 'No transceiver info available'.

- Parallelize all mlxlink/ethtool calls in Collect() using goroutines instead of sequential loops, reducing wall time from ~48s to ~22s
- Record PCIe BDF for IB-device primary net interfaces during enumeration
- Skip Ethernet interfaces that share a BDF with an already-collected IB interface (filters eth_vf_rep_* duplicates that report the same module)