### PR TITLE
feat(consts): differentiate alert colors by severity level

### DIFF
--- a/components/cpu/cpu.go
+++ b/components/cpu/cpu.go
@@ -262,7 +262,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 	for _, result := range checkerResults {
 		statusColor := consts.Green
 		if result.Status != consts.StatusNormal {
-			statusColor = consts.Red
+			statusColor = consts.LevelColor(result.Level)
 			checkAllPassed = false
 		}
 		switch result.Name {

--- a/components/dmesg/dmesg.go
+++ b/components/dmesg/dmesg.go
@@ -223,10 +223,10 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 	dmesgEvent := make(map[string]string)
 	checkAllPassed := true
 	checkerResults := result.Checkers
-	for _, result := range checkerResults {
-		if result.Status == consts.StatusAbnormal {
+	for _, checkerResult := range checkerResults {
+		if checkerResult.Status == consts.StatusAbnormal {
 			checkAllPassed = false
-			dmesgEvent[result.Name] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+			dmesgEvent[checkerResult.Name] = fmt.Sprintf("%s%s%s", consts.LevelColor(checkerResult.Level), checkerResult.Detail, consts.Reset)
 		}
 	}
 
@@ -235,7 +235,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 		fmt.Printf("%sNo Dmesg event detected%s\n", consts.Green, consts.Reset)
 		return checkAllPassed
 	}
-	fmt.Printf("%sDetected %d Types of Abnormal Dmesg Events:%s\n", consts.Red, len(dmesgEvent), consts.Reset)
+	fmt.Printf("%sDetected %d Types of Abnormal Dmesg Events:%s\n", consts.LevelColor(result.Level), len(dmesgEvent), consts.Reset)
 	for n := range dmesgEvent {
 		fmt.Printf("\t%s%s%s Events:\n %s\n", consts.Yellow, n, consts.Reset, dmesgEvent[n])
 	}

--- a/components/ethernet/ethernet.go
+++ b/components/ethernet/ethernet.go
@@ -276,13 +276,13 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 	for _, res := range checkerResults {
 		if res.Status != consts.StatusNormal && res.Level != consts.LevelInfo {
 			checkAllPassed = false
-			ethEvent[res.Name] = fmt.Sprintf("Event: %s%s%s -> %s", consts.Red, res.ErrorName, consts.Reset, strings.TrimRight(res.Detail, "\n"))
+			ethEvent[res.Name] = fmt.Sprintf("Event: %s%s%s -> %s", consts.LevelColor(res.Level), res.ErrorName, consts.Reset, strings.TrimRight(res.Detail, "\n"))
 		}
 
 		statusColor := consts.Green
 		statusText := "OK"
 		if res.Status != consts.StatusNormal {
-			statusColor = consts.Red
+			statusColor = consts.LevelColor(res.Level)
 			statusText = "Err"
 		}
 

--- a/components/gpfs/gpfs.go
+++ b/components/gpfs/gpfs.go
@@ -240,7 +240,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 	for _, result := range checkerResults {
 		if result.Status != consts.StatusNormal && result.Level != consts.LevelInfo {
 			checkAllPassed = false
-			gpfsEvent[result.Name] = fmt.Sprintf("Event: %s%s%s", consts.Red, result.ErrorName, consts.Reset)
+			gpfsEvent[result.Name] = fmt.Sprintf("Event: %s%s%s", consts.LevelColor(result.Level), result.ErrorName, consts.Reset)
 		}
 	}
 

--- a/components/gpuevents/gpuevents.go
+++ b/components/gpuevents/gpuevents.go
@@ -211,7 +211,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 	for _, result := range checkerResults {
 		if result.Status == consts.StatusAbnormal {
 			checkAllPassed = false
-			fmt.Printf("\t%s%s%s\n", consts.Red, result.Detail, consts.Reset)
+			fmt.Printf("\t%s%s%s\n", consts.LevelColor(result.Level), result.Detail, consts.Reset)
 		}
 	}
 	if checkAllPassed {

--- a/components/infiniband/infiniband.go
+++ b/components/infiniband/infiniband.go
@@ -355,7 +355,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 	for _, result := range checkerResults {
 		statusColor := consts.Green
 		if result.Status != consts.StatusNormal && result.Level != consts.LevelInfo {
-			statusColor = consts.Red
+			statusColor = consts.LevelColor(result.Level)
 			infinibandEvents[result.Name] = fmt.Sprintf("%s%s%s", statusColor, result.Detail, consts.Reset)
 			checkAllPassed = false
 		}

--- a/components/nvidia/nvidia.go
+++ b/components/nvidia/nvidia.go
@@ -685,6 +685,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 		if result.Status == consts.StatusAbnormal {
 			checkAllPassed = false
 		}
+		errColor := consts.LevelColor(result.Level)
 		switch result.Name {
 		case config.PCIeACSCheckerName:
 			if result.Status == consts.StatusNormal {
@@ -693,16 +694,16 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					systemEvent[config.PCIeACSCheckerName] = fmt.Sprintf("%s%s%s", consts.Yellow, result.Detail, consts.Reset)
 				}
 			} else {
-				acsPrint = fmt.Sprintf("PCIe ACS: %sEnabled%s", consts.Red, consts.Reset)
-				systemEvent[config.PCIeACSCheckerName] = fmt.Sprintf("%sNot All PCIe ACS Are Disabled%s", consts.Red, consts.Reset)
+				acsPrint = fmt.Sprintf("PCIe ACS: %sEnabled%s", errColor, consts.Reset)
+				systemEvent[config.PCIeACSCheckerName] = fmt.Sprintf("%sNot All PCIe ACS Are Disabled%s", errColor, consts.Reset)
 			}
 		case config.IBGDACheckerName:
 			if result.Status == consts.StatusNormal {
 				ibgdaPrint = fmt.Sprintf("IBGDA: %sEnabled%s", consts.Green, consts.Reset)
 			} else {
-				ibgdaPrint = fmt.Sprintf("IBGDA: %sDisabled%s", consts.Red, consts.Reset)
-				systemEvent[config.IBGDACheckerName] = fmt.Sprintf("%sIBGDA is not enabled correctly%s", consts.Red, consts.Reset)
-				systemEvent[config.IBGDACheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				ibgdaPrint = fmt.Sprintf("IBGDA: %sDisabled%s", errColor, consts.Reset)
+				systemEvent[config.IBGDACheckerName] = fmt.Sprintf("%sIBGDA is not enabled correctly%s", errColor, consts.Reset)
+				systemEvent[config.IBGDACheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.P2PCheckerName:
 			if result.Status == consts.StatusNormal {
@@ -712,15 +713,15 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					p2pPrint = fmt.Sprintf("P2P: %sOK%s", consts.Green, consts.Reset)
 				}
 			} else {
-				p2pPrint = fmt.Sprintf("P2P: %sError%s", consts.Red, consts.Reset)
-				systemEvent[config.P2PCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				p2pPrint = fmt.Sprintf("P2P: %sError%s", errColor, consts.Reset)
+				systemEvent[config.P2PCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.IOMMUCheckerName:
 			if result.Status == consts.StatusNormal {
 				iommuPrint = fmt.Sprintf("IOMMU: %sOFF%s", consts.Green, consts.Reset)
 			} else {
-				iommuPrint = fmt.Sprintf("IOMMU: %sON%s", consts.Red, consts.Reset)
-				systemEvent[config.IOMMUCheckerName] = fmt.Sprintf("%sIOMMU is ON%s", consts.Red, consts.Reset)
+				iommuPrint = fmt.Sprintf("IOMMU: %sON%s", errColor, consts.Reset)
+				systemEvent[config.IOMMUCheckerName] = fmt.Sprintf("%sIOMMU is ON%s", errColor, consts.Reset)
 			}
 		case config.NVFabricManagerCheckerName:
 			if result.Status == consts.StatusNormal {
@@ -729,8 +730,8 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					gpuStatus[config.NVFabricManagerCheckerName] = fmt.Sprintf("%s%s%s", consts.Yellow, result.Detail, consts.Reset)
 				}
 			} else {
-				fabricmanagerPrint = fmt.Sprintf("FabricManager: %sNot Active%s", consts.Red, consts.Reset)
-				gpuStatus[config.NVFabricManagerCheckerName] = fmt.Sprintf("%sNvidia FabricManager is not active%s", consts.Red, consts.Reset)
+				fabricmanagerPrint = fmt.Sprintf("FabricManager: %sNot Active%s", errColor, consts.Reset)
+				gpuStatus[config.NVFabricManagerCheckerName] = fmt.Sprintf("%sNvidia FabricManager is not active%s", errColor, consts.Reset)
 			}
 		case config.NvPeerMemCheckerName:
 			if result.Status == consts.StatusNormal {
@@ -739,14 +740,14 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					gpuStatus[config.NvPeerMemCheckerName] = fmt.Sprintf("%s%s%s", consts.Yellow, result.Detail, consts.Reset)
 				}
 			} else {
-				peermemPrint = fmt.Sprintf("nvidia_peermem: %sNotLoaded%s", consts.Red, consts.Reset)
-				gpuStatus[config.NvPeerMemCheckerName] = fmt.Sprintf("%snvidia_peermem module: NotLoaded%s", consts.Red, consts.Reset)
+				peermemPrint = fmt.Sprintf("nvidia_peermem: %sNotLoaded%s", errColor, consts.Reset)
+				gpuStatus[config.NvPeerMemCheckerName] = fmt.Sprintf("%snvidia_peermem module: NotLoaded%s", errColor, consts.Reset)
 			}
 		case config.PCIeCheckerName:
 			if result.Status == consts.StatusNormal {
 				pcieLinkPrint = fmt.Sprintf("PCIeLink: %sOK%s", consts.Green, consts.Reset)
 			} else {
-				gpuStatus[config.PCIeCheckerName] = fmt.Sprintf("%sPCIe degradation detected:\n%s%s%s", consts.Red, consts.Yellow, result.Detail, consts.Reset)
+				gpuStatus[config.PCIeCheckerName] = fmt.Sprintf("%sPCIe degradation detected:\n%s%s%s", errColor, consts.Yellow, result.Detail, consts.Reset)
 			}
 		case config.HardwareCheckerName:
 			if result.Status == consts.StatusNormal {
@@ -754,17 +755,17 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					consts.Green, nvidiaInfo.DeviceCount, consts.Reset, consts.Green, nvidiaInfo.DeviceUsedCount, consts.Reset)
 			} else {
 				gpuStatusPrint = fmt.Sprintf("%s%d GPUs detected, %d GPUs lost, %d GPUs used%s",
-					consts.Red, nvidiaInfo.DeviceCount, len(strings.Split(result.Device, ",")), nvidiaInfo.DeviceUsedCount, consts.Reset)
-				gpuStatus[config.HardwareCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+					errColor, nvidiaInfo.DeviceCount, len(strings.Split(result.Device, ",")), nvidiaInfo.DeviceUsedCount, consts.Reset)
+				gpuStatus[config.HardwareCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.SoftwareCheckerName:
 			if result.Status == consts.StatusNormal {
 				driverPrint = fmt.Sprintf("Driver Version: %s%s%s", consts.Green, nvidiaInfo.SoftwareInfo.DriverVersion, consts.Reset)
 				cudaVersionPrint = fmt.Sprintf("CUDA Version: %s%s%s", consts.Green, nvidiaInfo.SoftwareInfo.CUDAVersion, consts.Reset)
 			} else {
-				driverPrint = fmt.Sprintf("Driver Version: %s%s%s", consts.Red, nvidiaInfo.SoftwareInfo.DriverVersion, consts.Reset)
-				cudaVersionPrint = fmt.Sprintf("CUDA Version: %s%s%s", consts.Red, nvidiaInfo.SoftwareInfo.CUDAVersion, consts.Reset)
-				gpuStatus[config.SoftwareCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				driverPrint = fmt.Sprintf("Driver Version: %s%s%s", errColor, nvidiaInfo.SoftwareInfo.DriverVersion, consts.Reset)
+				cudaVersionPrint = fmt.Sprintf("CUDA Version: %s%s%s", errColor, nvidiaInfo.SoftwareInfo.CUDAVersion, consts.Reset)
+				gpuStatus[config.SoftwareCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.GpuPersistencedCheckerName:
 			if result.Status == consts.StatusNormal {
@@ -773,72 +774,72 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					gpuStatus[config.GpuPersistencedCheckerName] = fmt.Sprintf("%s%s%s", consts.Yellow, result.Detail, consts.Reset)
 				}
 			} else {
-				persistencePrint = fmt.Sprintf("Persistence Mode: %s%s%s", consts.Red, result.Curr, consts.Reset)
-				gpuStatus[config.GpuPersistencedCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				persistencePrint = fmt.Sprintf("Persistence Mode: %s%s%s", errColor, result.Curr, consts.Reset)
+				gpuStatus[config.GpuPersistencedCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.GpuPStateCheckerName:
 			if result.Status == consts.StatusNormal {
 				pstatePrint = fmt.Sprintf("PState: %s%s%s", consts.Green, result.Curr, consts.Reset)
 			} else {
-				pstatePrint = fmt.Sprintf("PState: %s%s%s", consts.Red, result.Curr, consts.Reset)
-				gpuStatus[config.GpuPStateCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				pstatePrint = fmt.Sprintf("PState: %s%s%s", errColor, result.Curr, consts.Reset)
+				gpuStatus[config.GpuPStateCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.NvlinkCheckerName:
 			if result.Status == consts.StatusNormal {
 				nvlinkPrint = fmt.Sprintf("NVLink: %s%s%s", consts.Green, result.Curr, consts.Reset)
 			} else {
 				nvlinkPrint = fmt.Sprintf("NVLink: %s%s%s", consts.Green, result.Curr, consts.Reset)
-				gpuStatus[config.NvlinkCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				gpuStatus[config.NvlinkCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.AppClocksCheckerName:
 			if result.Status == consts.StatusNormal {
 				// gpuStatus[config.AppClocksCheckerName] = fmt.Sprintf("%sGPU application clocks: Set to maximum%s", consts.Green, consts.Reset)
 			} else {
-				gpuStatus[config.AppClocksCheckerName] = fmt.Sprintf("%s%s%s", consts.Red, result.Detail, consts.Reset)
+				gpuStatus[config.AppClocksCheckerName] = fmt.Sprintf("%s%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.ClockEventsCheckerName:
 			if result.Status == consts.StatusNormal {
 				clockEvents["Thermal"] = fmt.Sprintf("%sNo HW Thermal Slowdown Found%s", consts.Green, consts.Reset)
 				clockEvents["PowerBrake"] = fmt.Sprintf("%sNo HW Power Brake Slowdown Found%s", consts.Green, consts.Reset)
 			} else {
-				clockEvents["Thermal"] = fmt.Sprintf("%sHW Thermal Slowdown Found%s", consts.Red, consts.Reset)
-				clockEvents["PowerBrake"] = fmt.Sprintf("%sHW Power Brake Slowdown Found%s", consts.Red, consts.Reset)
+				clockEvents["Thermal"] = fmt.Sprintf("%sHW Thermal Slowdown Found%s", errColor, consts.Reset)
+				clockEvents["PowerBrake"] = fmt.Sprintf("%sHW Power Brake Slowdown Found%s", errColor, consts.Reset)
 			}
 		case config.SRAMAggUncorrectableCheckerName:
 			if result.Status == consts.StatusNormal {
 				eccEvents[config.SRAMAggUncorrectableCheckerName] = fmt.Sprintf("%sNo SRAM Agg Uncorrectable Found%s", consts.Green, consts.Reset)
 			} else {
-				eccEvents[config.SRAMAggUncorrectableCheckerName] = fmt.Sprintf("%sSRAM Agg Uncorrectable Found\n%s%s", consts.Red, result.Detail, consts.Reset)
+				eccEvents[config.SRAMAggUncorrectableCheckerName] = fmt.Sprintf("%sSRAM Agg Uncorrectable Found\n%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.SRAMHighcorrectableCheckerName:
 			if result.Status == consts.StatusNormal {
 				eccEvents[config.SRAMHighcorrectableCheckerName] = fmt.Sprintf("%sNo SRAM High Correctable Found%s", consts.Green, consts.Reset)
 			} else {
-				eccEvents[config.SRAMHighcorrectableCheckerName] = fmt.Sprintf("%sSRAM High Correctable Found\n%s%s", consts.Red, result.Detail, consts.Reset)
+				eccEvents[config.SRAMHighcorrectableCheckerName] = fmt.Sprintf("%sSRAM High Correctable Found\n%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.SRAMVolatileUncorrectableCheckerName:
 			if result.Status == consts.StatusNormal {
 				eccEvents[config.SRAMVolatileUncorrectableCheckerName] = fmt.Sprintf("%sNo SRAM Volatile Uncorrectable Found%s", consts.Green, consts.Reset)
 			} else {
-				eccEvents[config.SRAMVolatileUncorrectableCheckerName] = fmt.Sprintf("%sSRAM Volatile Uncorrectable Found\n%s%s", consts.Red, result.Detail, consts.Reset)
+				eccEvents[config.SRAMVolatileUncorrectableCheckerName] = fmt.Sprintf("%sSRAM Volatile Uncorrectable Found\n%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.RemmapedRowsFailureCheckerName:
 			if result.Status == consts.StatusNormal {
 				remmapedRowsEvents[config.RemmapedRowsFailureCheckerName] = fmt.Sprintf("%sNo Remmaped Rows Failure Found%s", consts.Green, consts.Reset)
 			} else {
-				remmapedRowsEvents[config.RemmapedRowsFailureCheckerName] = fmt.Sprintf("%sRemmaped Rows Failure Found\n%s%s", consts.Red, result.Detail, consts.Reset)
+				remmapedRowsEvents[config.RemmapedRowsFailureCheckerName] = fmt.Sprintf("%sRemmaped Rows Failure Found\n%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.RemmapedRowsUncorrectableCheckerName:
 			if result.Status == consts.StatusNormal {
 				remmapedRowsEvents[config.RemmapedRowsUncorrectableCheckerName] = fmt.Sprintf("%sNo Remmaped Rows Uncorrectable Found%s", consts.Green, consts.Reset)
 			} else {
-				remmapedRowsEvents[config.RemmapedRowsUncorrectableCheckerName] = fmt.Sprintf("%sRemmaped Rows Uncorrectable Found\n%s%s", consts.Red, result.Detail, consts.Reset)
+				remmapedRowsEvents[config.RemmapedRowsUncorrectableCheckerName] = fmt.Sprintf("%sRemmaped Rows Uncorrectable Found\n%s%s", errColor, result.Detail, consts.Reset)
 			}
 		case config.RemmapedRowsPendingCheckerName:
 			if result.Status == consts.StatusNormal {
 				remmapedRowsEvents[config.RemmapedRowsPendingCheckerName] = fmt.Sprintf("%sNo Remmaped Rows Pending Found%s", consts.Green, consts.Reset)
 			} else {
-				remmapedRowsEvents[config.RemmapedRowsPendingCheckerName] = fmt.Sprintf("%sRemmaped Rows Pending Found\n%s%s", consts.Red, result.Detail, consts.Reset)
+				remmapedRowsEvents[config.RemmapedRowsPendingCheckerName] = fmt.Sprintf("%sRemmaped Rows Pending Found\n%s%s", errColor, result.Detail, consts.Reset)
 			}
 		}
 	}

--- a/components/pcie/topotest/topo_checker.go
+++ b/components/pcie/topotest/topo_checker.go
@@ -209,7 +209,7 @@ func PrintInfo(result *common.Result, verbos bool) bool {
 	}
 	for _, result := range checkerResults {
 		if result.Status == consts.StatusAbnormal {
-			fmt.Printf("%s%s%s\n", consts.Red, result.ErrorName, consts.Reset)
+			fmt.Printf("%s%s%s\n", consts.LevelColor(result.Level), result.ErrorName, consts.Reset)
 			fmt.Printf("%s\n", result.Detail)
 		}
 	}

--- a/components/podlog/podlog.go
+++ b/components/podlog/podlog.go
@@ -385,7 +385,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 		for _, checkerResult := range checkerResults {
 			if checkerResult.Status == consts.StatusAbnormal {
 				checkAllPassed = false
-				fmt.Printf("\t%sDetected %s error for %s times in %s%s\n", consts.Red, checkerResult.ErrorName, checkerResult.Curr, checkerResult.Device, consts.Reset)
+				fmt.Printf("\t%sDetected %s error for %s times in %s%s\n", consts.LevelColor(checkerResult.Level), checkerResult.ErrorName, checkerResult.Curr, checkerResult.Device, consts.Reset)
 			}
 		}
 	}

--- a/components/syslog/syslog.go
+++ b/components/syslog/syslog.go
@@ -262,7 +262,7 @@ func (c *component) PrintInfo(info common.Info /*ignored*/, result *common.Resul
 		for _, result := range checkerResults {
 			if result.Status == consts.StatusAbnormal {
 				checkAllPassed = false
-				syslogEvents[result.Name] = fmt.Sprintf("%sDetect %s %v times in %s %s", consts.Red, result.ErrorName, result.Curr, result.Device, consts.Reset)
+				syslogEvents[result.Name] = fmt.Sprintf("%sDetect %s %v times in %s %s", consts.LevelColor(result.Level), result.ErrorName, result.Curr, result.Device, consts.Reset)
 			}
 		}
 	}

--- a/components/transceiver/transceiver.go
+++ b/components/transceiver/transceiver.go
@@ -281,7 +281,7 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 					fmt.Printf("\nErrors Events:\n")
 					hasErrors = true
 				}
-				fmt.Printf("\tEvent: %s%s%s -> %s\n", consts.Red, res.ErrorName, consts.Reset, res.Detail)
+				fmt.Printf("\tEvent: %s%s%s -> %s\n", consts.LevelColor(res.Level), res.ErrorName, consts.Reset, res.Detail)
 			}
 		}
 		if !hasErrors {

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -133,6 +133,18 @@ const (
 	Cyan   = "\033[36m"
 	White  = "\033[37m"
 )
+// LevelColor returns the ANSI color for a given severity level.
+func LevelColor(level string) string {
+	switch level {
+	case LevelWarning:
+		return Yellow
+	case LevelCritical, LevelFatal:
+		return Red
+	default:
+		return Green
+	}
+}
+
 const PadLen = len(Green) + len(Reset)
 const CmdTimeout = 30 * time.Second
 const IbPerfTestTimeout = 600 * time.Second


### PR DESCRIPTION
Replace hardcoded consts.Red in component PrintInfo with a new LevelColor(level) helper that maps:
  - LevelWarning              -> Yellow
  - LevelCritical / LevelFatal -> Red
  - other                     -> Green

Applied across cpu, dmesg, ethernet, gpfs, gpuevents, infiniband, nvidia, pcie/topotest, podlog, syslog, transceiver so warnings no longer share the same red color as critical/fatal events.