### PR TITLE
feat(infiniband): allow_vf opt-in lets spec.ib_devs include SR-IOV VFs

### DIFF
--- a/components/hca/config/spec.go
+++ b/components/hca/config/spec.go
@@ -46,7 +46,7 @@ type HCAPerf struct {
 func EnsureSpec(file string) (string, error) {
 	const comp = "hca/spec"
 
-	_, boardIDs, err := GetIBPFBoardIDs()
+	_, boardIDs, err := GetIBPFBoardIDs(nil)
 	if err != nil {
 		return file, fmt.Errorf("EnsureSpec: cannot detect board IDs: %w", err)
 	}
@@ -299,7 +299,7 @@ func FilterSpecsForLocalHost(file string, allSpecs *HCASpecs) (*HCASpecs, error)
 	if allSpecs == nil || allSpecs.GetMap() == nil {
 		return nil, fmt.Errorf("HCA spec is not initialized")
 	}
-	_, ibDevs, err := GetIBPFBoardIDs()
+	_, ibDevs, err := GetIBPFBoardIDs(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -326,20 +326,34 @@ func FilterSpecsForLocalHost(file string, allSpecs *HCASpecs) (*HCASpecs, error)
 	// the source of truth maintained by humans.
 	return result, nil
 }
-func GetIBPFBoardIDs() (map[string]string, []string, error) {
+// GetIBPFBoardIDs scans /sys/class/infiniband and returns:
+//   - devBoardIDMap: map of IB device name -> board_id
+//   - boardIDs:      deduplicated list of board IDs
+//
+// Filtering rules:
+//   - mezzanine cards are always skipped (legacy)
+//   - low-speed bond aggregations are always skipped (legacy)
+//   - if `allowed` is non-nil and non-empty, ONLY device names present in
+//     `allowed` are returned (PF or VF). This lets a spec that lists VFs
+//     bring those VFs into scope and lets a spec that lists PFs exclude
+//     auto-discovered PFs that are not part of the cluster baseline.
+//   - if `allowed` is nil or empty, fall back to legacy behavior: skip VFs
+//     (devices with a `physfn` symlink), keep all other PFs.
+func GetIBPFBoardIDs(allowed map[string]string) (map[string]string, []string, error) {
 	baseDir := "/sys/class/infiniband"
 	devices, err := os.ReadDir(baseDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read %s: %v", baseDir, err)
 	}
 
+	useAllowlist := len(allowed) > 0
+
 	boardIDSet := make(map[string]struct{})
 	devBoardIDMap := make(map[string]string)
 	for _, dev := range devices {
 		devName := dev.Name()
-		vfPath := filepath.Join(baseDir, devName, "device", "physfn")
-		if _, err := os.Stat(vfPath); err == nil {
-			continue // Skip virtual functions
+		if strings.Contains(devName, "mezz") {
+			continue // Skip mezzanine card
 		}
 		if utils.IsLowSpeedIBBond(devName) {
 			// Skip bond IB devices that look like management
@@ -347,9 +361,20 @@ func GetIBPFBoardIDs() (map[string]string, []string, error) {
 			// are kept and participate in HCA enumeration.
 			continue
 		}
-		if strings.Contains(devName, "mezz") {
-			continue // Skip mezzanine card
+
+		if useAllowlist {
+			if _, ok := allowed[devName]; !ok {
+				continue // Strict allowlist: only spec-listed names participate
+			}
+			// Listed device — keep it regardless of PF/VF
+		} else {
+			// Legacy: skip virtual functions
+			vfPath := filepath.Join(baseDir, devName, "device", "physfn")
+			if _, err := os.Stat(vfPath); err == nil {
+				continue
+			}
 		}
+
 		boardIDPath := filepath.Join(baseDir, devName, "board_id")
 		content, err := os.ReadFile(boardIDPath)
 		if err != nil {

--- a/components/hca/config/spec_test.go
+++ b/components/hca/config/spec_test.go
@@ -151,7 +151,7 @@ func TestLoadSpecFromRemoteURL(t *testing.T) {
 }
 
 func TestGetBoardIDs(t *testing.T) {
-	_, boardIDs, err := GetIBPFBoardIDs()
+	_, boardIDs, err := GetIBPFBoardIDs(nil)
 	if err != nil {
 		t.Fatalf("getBoardIDs() returned an error: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestGetBoardIDs(t *testing.T) {
 }
 
 func TestLoadSpec(t *testing.T) {
-	_, boardIDs, _ := GetIBPFBoardIDs()
+	_, boardIDs, _ := GetIBPFBoardIDs(nil)
 	if len(boardIDs) == 1 && boardIDs[0] == "MT_0000000970" {
 		hcaSpec, err := LoadSpec("")
 		if err != nil {

--- a/components/infiniband/collector/infiniband_info.go
+++ b/components/infiniband/collector/infiniband_info.go
@@ -41,24 +41,29 @@ type InfinibandInfo struct {
 	IBSoftWareInfo  IBSoftWareInfo            `json:"ib_software_info" yaml:"ib_software_info"`
 	// PCIETreeInfo   map[string]PCIETreeInfo   `json:"pcie_tree_info" yaml:"pcie_tree_info"`
 	IBCounters map[string]IBCounters `json:"ib_counters" yaml:"ib_counters"`
-	IBNicRole  string                `json:"ib_nic_role" yaml:"ib_nic_role"`
-	Time       time.Time             `json:"time" yaml:"time"`
-	mu         sync.RWMutex
+	IBNicRole   string                `json:"ib_nic_role" yaml:"ib_nic_role"`
+	allowedDevs map[string]string     // spec.ib_devs allowlist; nil/empty = legacy auto-discover
+	Time        time.Time             `json:"time" yaml:"time"`
+	mu          sync.RWMutex
 }
 
-func NewIBCollector(ctx context.Context) (*InfinibandInfo, error) {
+func NewIBCollector(ctx context.Context, allowed map[string]string) (*InfinibandInfo, error) {
 	i := &InfinibandInfo{
 		IBHardWareInfo: make(map[string]IBHardWareInfo),
 		IBSoftWareInfo: IBSoftWareInfo{},
 		// PCIETreeInfo:   make(map[string]PCIETreeInfo),
-		IBPFDevs:   make(map[string]string),
-		IBCounters: make(map[string]IBCounters),
-		mu:         sync.RWMutex{},
+		IBPFDevs:    make(map[string]string),
+		IBCounters:  make(map[string]IBCounters),
+		allowedDevs: allowed,
+		mu:          sync.RWMutex{},
 	}
 	i.IBNicRole = i.GetNICRole()
 	var err error
-	// Get PCIe device list at collector initialization
-	i.IBPCIDevs, err = GetRDMACapablePCIeDevices()
+	// Get PCIe device list at collector initialization.
+	// When the spec carries an allowlist (SR-IOV node listing VFs), include VFs
+	// in the scan so the trim step in Collect can keep VF BDFs that back the
+	// IB devices we actually want to check.
+	i.IBPCIDevs, err = GetRDMACapablePCIeDevices(len(allowed) > 0)
 	i.IBCapablePCINum = len(i.IBPCIDevs)
 	if err != nil {
 		logrus.WithField("component", "infiniband").Warnf("Failed to find PCI devices: %v", err)
@@ -107,6 +112,7 @@ func (i *InfinibandInfo) Collect(ctx context.Context) (common.Info, error) {
 		IBNicRole:       i.IBNicRole,
 		IBPCIDevs:       i.IBPCIDevs,
 		IBCapablePCINum: i.IBCapablePCINum,
+		allowedDevs:     i.allowedDevs,
 	}
 
 	newInfo.IBPFDevs = i.GetIBPFdevs()
@@ -209,27 +215,30 @@ func ignoreVirtualFunction(ibDev string) bool {
 }
 
 func (i *InfinibandInfo) GetPFDevs(IBDevs []string) []string {
+	useAllowlist := len(i.allowedDevs) > 0
 	PFDevs := make([]string, 0)
 	for _, IBDev := range IBDevs {
-
-		// // ignore cx4 interface: why???
-		// shouldIgnore := ignoreByHCATYPE(IBDev)
-		// if shouldIgnore {
-		// 	continue
-		// }
-
-		// ignore virtual functions
-		shouldIgnore := ignoreVirtualFunction(IBDev)
-		if shouldIgnore {
+		if useAllowlist {
+			if _, ok := i.allowedDevs[IBDev]; !ok {
+				continue // Strict allowlist: only spec-listed names participate
+			}
+			// Listed device — keep it regardless of PF/VF
+			PFDevs = append(PFDevs, IBDev)
 			continue
 		}
-
+		// Legacy: skip virtual functions, keep PFs
+		if ignoreVirtualFunction(IBDev) {
+			continue
+		}
 		PFDevs = append(PFDevs, IBDev)
 	}
 	return PFDevs
 }
 
-// GetIBPFdevs Get IB PF devices igoring virtual functions and bond devices
+// GetIBPFdevs returns the IB devices to check on this node.
+// When the InfinibandInfo carries a non-empty allowlist (from spec.ib_devs),
+// only listed names are returned (PF or VF). Otherwise legacy behavior:
+// auto-discover PFs and skip VFs. Mezzanine and low-speed bonds are always skipped.
 func (i *InfinibandInfo) GetIBPFdevs() map[string]string {
 	allIBDevs, err := GetFileCnt(IBSYSPathPre)
 	if err != nil {

--- a/components/infiniband/collector/pcie_info.go
+++ b/components/infiniband/collector/pcie_info.go
@@ -42,8 +42,13 @@ var (
 	}
 )
 
-// FindIBPCIDevices finds RDMA-capable PCI devices by checking infiniband sysfs, and ignore virtual functions
-func GetRDMACapablePCIeDevices() (map[string]string, error) {
+// GetRDMACapablePCIeDevices finds RDMA-capable PCI devices by checking infiniband sysfs.
+// When `includeVFs` is false, virtual functions are skipped (legacy behavior).
+// When `includeVFs` is true, VFs whose underlying PCI device backs an IB device
+// are returned alongside PFs; downstream callers must trim by IBPFDevs to keep
+// only the BDFs they care about. Used by SR-IOV nodes whose data path runs
+// over VFs.
+func GetRDMACapablePCIeDevices(includeVFs bool) (map[string]string, error) {
 	if _, err := os.Stat(PCIPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("pci devices directory not found at %s: %w", PCIPath, err)
 	}
@@ -59,7 +64,7 @@ func GetRDMACapablePCIeDevices() (map[string]string, error) {
 		pciAddr := entry.Name()
 		deviceDir := filepath.Join(PCIPath, pciAddr)
 		isVirtualFunction, err := IsVirtualFunctionByBDF(pciAddr)
-		if isVirtualFunction {
+		if isVirtualFunction && !includeVFs {
 			continue
 		}
 		if err != nil {

--- a/components/infiniband/config/spec.go
+++ b/components/infiniband/config/spec.go
@@ -35,6 +35,14 @@ type InfinibandSpec struct {
 	IBPFDevs       map[string]string         `json:"ib_devs" yaml:"ib_devs"`
 	IBSoftWareInfo *collector.IBSoftWareInfo `json:"sw_deps" yaml:"sw_deps"`
 	PCIeACS        string                    `json:"pcie_acs" yaml:"pcie_acs"`
+	// AllowVF opts this cluster's spec into the SR-IOV-aware behavior:
+	// when true, ib_devs is treated as an authoritative allowlist that
+	// may include VF names (the data path on these nodes runs over VFs).
+	// when false (default), legacy behavior applies: ib_devs is a hint
+	// used only for trimming, the collector auto-discovers PFs and VFs
+	// are unconditionally skipped. Default false preserves backward
+	// compatibility for every existing cluster spec.
+	AllowVF bool `json:"allow_vf,omitempty" yaml:"allow_vf,omitempty"`
 
 	// HCAs is for in-memory use only (full specs)
 	HCAs map[string]*hcaConfig.HCASpec `json:"-" yaml:"-"`
@@ -78,8 +86,15 @@ func FilterSpec(specs *InfinibandSpecs, file string) (*InfinibandSpec, error) {
 		} else {
 			return nil, fmt.Errorf("no infiniband specification for cluster %s and no default in %s", clusterName, file)
 		}
-		// Get the board IDs of the IB devices in the host
-		devBoardIDMap, ibDevs, err := hcaConfig.GetIBPFBoardIDs()
+		// Get the board IDs of the IB devices in the host.
+		// When the spec opts into VF-aware behavior, scope the host scan to
+		// spec-listed names so VFs explicitly named in ib_devs are admitted.
+		// Otherwise stay with legacy behavior (skip VFs, auto-discover PFs).
+		var hostScanAllow map[string]string
+		if ibSpec.AllowVF {
+			hostScanAllow = ibSpec.IBPFDevs
+		}
+		devBoardIDMap, ibDevs, err := hcaConfig.GetIBPFBoardIDs(hostScanAllow)
 		if err != nil {
 			return nil, err
 		}

--- a/components/infiniband/config/spec_test.go
+++ b/components/infiniband/config/spec_test.go
@@ -123,7 +123,7 @@ hca:
 	}
 
 	// Test the LoadSpec function
-	_, nic, err := hcaConfig.GetIBPFBoardIDs()
+	_, nic, err := hcaConfig.GetIBPFBoardIDs(nil)
 	if err != nil {
 		t.Skip("Skipping test due to error in GetIBPFBoardIDs: ", err)
 	}
@@ -303,5 +303,116 @@ hca:
 			}
 		}
 		break
+	}
+}
+
+// firstVFOnHost returns the name of any VF currently exposed in
+// /sys/class/infiniband, or "" if there is none. Used by VF-aware tests
+// so they self-skip on dev hosts without SR-IOV.
+func firstVFOnHost() string {
+	devices, err := os.ReadDir("/sys/class/infiniband")
+	if err != nil {
+		return ""
+	}
+	for _, d := range devices {
+		vfPath := "/sys/class/infiniband/" + d.Name() + "/device/physfn"
+		if _, err := os.Stat(vfPath); err == nil {
+			return d.Name()
+		}
+	}
+	return ""
+}
+
+// TestFilterSpec_AllowVF_True verifies that when spec.ib_devs lists VF
+// names AND allow_vf: true is set, FilterSpec preserves those entries via
+// the allowlist passed to GetIBPFBoardIDs. The test runs only on hosts
+// that actually expose at least one VF; otherwise it skips.
+func TestFilterSpec_AllowVF_True(t *testing.T) {
+	firstVF := firstVFOnHost()
+	if firstVF == "" {
+		t.Skip("no VF on this host; skipping AllowVF=true test")
+	}
+
+	specData := `
+nvidia: {}
+infiniband:
+  default:
+    allow_vf: true
+    ib_devs:
+      ` + firstVF + `: dummy_net
+    sw_deps:
+      kernel_module: ["mlx5_core"]
+      ofed_ver: ">=24.10"
+    pcie_acs: "disable"
+hca: {}
+`
+	specFile, err := os.CreateTemp("", "spec_*.yaml")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(specFile.Name())
+	if _, err := specFile.Write([]byte(specData)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	specFile.Close()
+
+	spec, err := LoadSpec(specFile.Name())
+	// LoadSpec may return an error about missing HCA spec for the VF's
+	// board id (the `hca: {}` block has no entry); the assertion below
+	// only cares that the VF survived FilterSpec/trim.
+	if spec == nil {
+		t.Fatalf("LoadSpec returned nil spec: %v", err)
+	}
+	if !spec.AllowVF {
+		t.Fatalf("expected spec.AllowVF == true after unmarshal, got false")
+	}
+	if _, ok := spec.IBPFDevs[firstVF]; !ok {
+		t.Fatalf("expected VF %q to remain in spec.IBPFDevs after FilterSpec, got %v", firstVF, spec.IBPFDevs)
+	}
+}
+
+// TestFilterSpec_AllowVF_Default verifies that without allow_vf in the
+// spec (legacy specs on every existing cluster), a VF named in ib_devs
+// is treated as today: the host scan skips VFs, so trim removes the VF
+// from spec.IBPFDevs. This is the regression guard for clnet36-style
+// nodes whose spec happens to list mlx5_4..7 names that resolve to VFs
+// on some hosts.
+func TestFilterSpec_AllowVF_Default(t *testing.T) {
+	firstVF := firstVFOnHost()
+	if firstVF == "" {
+		t.Skip("no VF on this host; skipping AllowVF default test")
+	}
+
+	specData := `
+nvidia: {}
+infiniband:
+  default:
+    ib_devs:
+      ` + firstVF + `: dummy_net
+    sw_deps:
+      kernel_module: ["mlx5_core"]
+      ofed_ver: ">=24.10"
+    pcie_acs: "disable"
+hca: {}
+`
+	specFile, err := os.CreateTemp("", "spec_*.yaml")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(specFile.Name())
+	if _, err := specFile.Write([]byte(specData)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	specFile.Close()
+
+	spec, err := LoadSpec(specFile.Name())
+	if spec == nil {
+		t.Fatalf("LoadSpec returned nil spec: %v", err)
+	}
+	if spec.AllowVF {
+		t.Fatalf("expected spec.AllowVF == false (default), got true")
+	}
+	if _, ok := spec.IBPFDevs[firstVF]; ok {
+		t.Fatalf("expected VF %q to be trimmed from spec.IBPFDevs when AllowVF=false, but it survived: %v", firstVF, spec.IBPFDevs)
 	}
 }

--- a/components/infiniband/infiniband.go
+++ b/components/infiniband/infiniband.go
@@ -136,7 +136,14 @@ func newInfinibandComponent(cfgFile string, specFile string, ignoredCheckers []s
 	}
 
 	// create collector
-	collector, err := collector.NewIBCollector(ctx)
+	// Only opt the collector into the SR-IOV-aware allowlist path when the
+	// spec explicitly enables it via allow_vf. Otherwise pass nil so the
+	// collector keeps the legacy behavior (auto-discover PFs, skip VFs).
+	var collectorAllow map[string]string
+	if ibSpec.AllowVF {
+		collectorAllow = ibSpec.IBPFDevs
+	}
+	collector, err := collector.NewIBCollector(ctx, collectorAllow)
 	if err != nil {
 		logrus.WithField("component", "infiniband").WithError(err).Error("failed to create infiniband collector")
 		component.initError = fmt.Errorf("failed to create infiniband collector: %w", err)


### PR DESCRIPTION
Adds an explicit AllowVF flag to InfinibandSpec. When false (default, matches every existing cluster spec), the collector keeps legacy behavior: auto-discover PFs, skip VFs, and use ib_devs only as a trim hint. When true, ib_devs becomes the authoritative allowlist on this node — listed names participate in the check chain regardless of PF or VF, and unlisted devices are excluded.

This unblocks SR-IOV nodes whose data path runs over VFs (rdma system shared, PF intentionally Disabled): the spec lists roce_vf_r* names, sets allow_vf: true, and sichek now actually checks those VFs instead of the unused PFs.

Plumbing changes:
  * GetIBPFBoardIDs accepts an optional allowlist (nil = legacy)
  * NewIBCollector accepts the same allowlist; FilterSpec and newInfinibandComponent only pass it when ibSpec.AllowVF == true
  * GetRDMACapablePCIeDevices accepts includeVFs so the per-collect trim sees VF BDFs and IBCapablePCINum stays aligned with HCAPCINum on SR-IOV nodes (fixes the spurious check_ib_lost mismatch)
  * Two new tests guard both directions: AllowVF=true admits a host VF, default-false leaves VF behavior unchanged

Verified on four reference nodes:
  * clnet36 (PF + 32 VF, changliu): PASS unchanged
  * lmg86 (PF-only, longmen): PASS unchanged
  * thg1 (PF-only IB, taihua): PASS unchanged
  * zy3 (SR-IOV VF data path, default fallback) with allow_vf: true: 8 VFs enter the check chain, PFs and mezzanines are skipped, check_ib_devs and check_ib_lost report consistent state