### PR TITLE
fix(nvidia): 限制 nvidia-smi 启动探测超时,避免坏卡把 daemon 拖入无限重启

### DIFF
--- a/components/nvidia/collector/collector.go
+++ b/components/nvidia/collector/collector.go
@@ -27,11 +27,19 @@ import (
 
 	"github.com/scitix/sichek/components/common"
 	"github.com/scitix/sichek/components/nvidia/utils"
+	"github.com/scitix/sichek/consts"
 	"github.com/scitix/sichek/pkg/k8s"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/sirupsen/logrus"
 )
+
+// ErrSWInfoProbeTimeout marks a NewNvidiaCollector failure caused specifically
+// by the nvidia-smi startup probe exceeding consts.NvidiaSWInfoProbeTimeout
+// (i.e. the nvidia-smi query path is hung, not merely returning an error).
+// Callers use errors.Is to distinguish this from generic init failures so it can
+// be reported under a dedicated ErrorName for recovery automation.
+var ErrSWInfoProbeTimeout = errors.New("nvidia-smi startup probe timed out")
 
 type NvidiaCollector struct {
 	// only collect once as it is collected by `nvidia-smi -q -i 0`
@@ -54,8 +62,16 @@ func NewNvidiaCollector(ctx context.Context, nvmlInstPtr *nvml.Interface, expect
 	}
 	collector := &NvidiaCollector{nvmlInst: nvmlInstPtr, podResourceMapper: podResourceMapper}
 	var err error
+	// Bound the nvidia-smi driver/CUDA-version probe with a short dedicated
+	// timeout. A hung `nvidia-smi -q` (e.g. an NVLink fault stalling the query
+	// path) must not keep daemon startup on the systemd "activating" path longer
+	// than the DaemonSet keepalive tolerates, or it triggers an endless
+	// start/kill loop. On timeout the loop below returns ErrSWInfoProbeTimeout and
+	// the NVIDIA component reports a distinct Critical error instead of blocking.
+	swCtx, swCancel := context.WithTimeout(ctx, consts.NvidiaSWInfoProbeTimeout)
+	defer swCancel()
 	for i := 0; i < expectedDeviceCount; i++ {
-		err = collector.softwareInfo.Get(ctx, i)
+		err = collector.softwareInfo.Get(swCtx, i)
 		if err != nil {
 			logrus.WithField("component", "NVIDIA-Collector-getSWInfo").Errorf("%v", err)
 		} else {
@@ -88,7 +104,13 @@ func NewNvidiaCollector(ctx context.Context, nvmlInstPtr *nvml.Interface, expect
 			return nil, fmt.Errorf("failed to get UUID during collector initialization: %w", err)
 		}
 	} else {
-		return nil, fmt.Errorf("failed to NewNvidiaCollector: %v", err)
+		// A deadline on swCtx means the nvidia-smi probe itself hung rather than
+		// failing fast; surface that as a distinct sentinel so the component can
+		// report it under a dedicated ErrorName instead of the generic InitError.
+		if errors.Is(swCtx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w (last probe error: %v)", ErrSWInfoProbeTimeout, err)
+		}
+		return nil, fmt.Errorf("failed to NewNvidiaCollector: %w", err)
 	}
 	return collector, nil
 }

--- a/components/nvidia/nvidia.go
+++ b/components/nvidia/nvidia.go
@@ -343,14 +343,26 @@ func (c *component) checkInitError() (*common.Result, bool) {
 	}
 
 	logrus.WithField("component", "nvidia").Errorf("report initError: %v", c.initError)
+	// Default to the generic InitError identity. When init failed specifically
+	// because the nvidia-smi startup probe hung, report a distinct ErrorName so
+	// recovery automation can act on that condition without colliding with the
+	// actions already keyed to InitError.
+	name := "InitError"
+	description := "Nvidia component initialization failed"
+	suggestion := "Please check the initialization logs and ensure all dependencies are properly configured"
+	if errors.Is(c.initError, collector.ErrSWInfoProbeTimeout) {
+		name = consts.NvidiaSMITimeoutErrName
+		description = "nvidia-smi did not respond within the startup probe timeout; the GPU query path appears hung"
+		suggestion = "nvidia-smi is unresponsive (commonly an NVLink or driver hang). Drain the node and reset the GPUs (nvidia-smi -r) or reboot; if it persists after reset, treat it as hardware."
+	}
 	checkerResult := &common.CheckerResult{
-		Name:        "InitError",
-		Description: "Nvidia component initialization failed",
+		Name:        name,
+		Description: description,
 		Status:      consts.StatusAbnormal,
 		Level:       consts.LevelCritical,
 		Curr:        c.initError.Error(),
-		ErrorName:   "InitError",
-		Suggestion:  "Please check the initialization logs and ensure all dependencies are properly configured",
+		ErrorName:   name,
+		Suggestion:  suggestion,
 	}
 	result := &common.Result{
 		Item:     consts.ComponentNameNvidia,

--- a/components/nvidia/nvidia_test.go
+++ b/components/nvidia/nvidia_test.go
@@ -17,12 +17,65 @@ package nvidia
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/scitix/sichek/components/common"
+	"github.com/scitix/sichek/components/nvidia/collector"
+	"github.com/scitix/sichek/consts"
 )
+
+func TestCheckInitError_Classification(t *testing.T) {
+	tests := []struct {
+		name          string
+		initError     error
+		wantReported  bool
+		wantErrorName string
+	}{
+		{
+			name:         "no init error",
+			initError:    nil,
+			wantReported: false,
+		},
+		{
+			name:          "nvidia-smi probe timeout maps to NvidiaSMITimeout",
+			initError:     fmt.Errorf("failed to create nvidia collector: %w", fmt.Errorf("wrap: %w", collector.ErrSWInfoProbeTimeout)),
+			wantReported:  true,
+			wantErrorName: consts.NvidiaSMITimeoutErrName,
+		},
+		{
+			name:          "generic init failure stays InitError",
+			initError:     fmt.Errorf("spec loading failed: boom"),
+			wantReported:  true,
+			wantErrorName: "InitError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &component{componentName: consts.ComponentNameNvidia, initError: tt.initError}
+			result, ok := c.checkInitError()
+			if ok != tt.wantReported {
+				t.Fatalf("checkInitError reported=%v, want %v", ok, tt.wantReported)
+			}
+			if !tt.wantReported {
+				return
+			}
+			if len(result.Checkers) != 1 {
+				t.Fatalf("expected 1 checker result, got %d", len(result.Checkers))
+			}
+			cr := result.Checkers[0]
+			if cr.ErrorName != tt.wantErrorName || cr.Name != tt.wantErrorName {
+				t.Fatalf("ErrorName/Name = %q/%q, want %q", cr.ErrorName, cr.Name, tt.wantErrorName)
+			}
+			if cr.Level != consts.LevelCritical {
+				t.Fatalf("Level = %q, want %q", cr.Level, consts.LevelCritical)
+			}
+		})
+	}
+}
 
 func TestHealthCheck(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -174,6 +174,24 @@ func LevelColor(level string) string {
 
 const PadLen = len(Green) + len(Reset)
 const CmdTimeout = 30 * time.Second
+
+// NvidiaSWInfoProbeTimeout bounds the `nvidia-smi -q` driver/CUDA-version probe
+// run during NVIDIA collector initialization so a hung nvidia-smi (e.g. an
+// NVLink fault stalling the query path) cannot block daemon startup for the full
+// 30s CmdTimeout. On timeout the NVIDIA component reports a Critical InitError
+// instead of holding the systemd "activating" state open indefinitely. This is a
+// bound, not the loop fix: the DaemonSet keepalive tolerating the "activating"
+// state is what actually prevents the start/kill loop, so this value only needs
+// to keep startup reasonably prompt.
+const NvidiaSWInfoProbeTimeout = 9 * time.Second
+
+// NvidiaSMITimeoutErrName is the CheckerResult Name/ErrorName reported when the
+// nvidia-smi startup probe (SoftwareInfo.Get) exceeds NvidiaSWInfoProbeTimeout.
+// It is kept distinct from the generic "InitError" so recovery automation can
+// key on this specific "nvidia-smi query path is hung" condition (annotation
+// error_name and the sichek_nvidia_<name> metric series both derive from it).
+const NvidiaSMITimeoutErrName = "NvidiaSMITimeout"
+
 const IbPerfTestTimeout = 600 * time.Second
 const AllCmdTimeout = 60 * time.Second
 const DefaultCacheLine int64 = 10000              // Default cache line number for event filter

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -101,10 +101,18 @@ spec:
           TAIL_PID=$!
 
           while true; do
-            if ! $HOST systemctl is-active --quiet sichek; then
-              echo "[sichek] service not active, restarting"
-              $HOST sichek d start
-            fi
+            # Only restart when the unit is genuinely down. "activating" (a slow
+            # first start, e.g. nvidia-smi probing GPUs) and "active" are healthy,
+            # so we never kill an in-progress start; systemd TimeoutStartSec=300
+            # is the backstop for a truly stuck start.
+            state=$($HOST systemctl show -p ActiveState --value sichek 2>/dev/null || true)
+            case "$state" in
+              active|activating|reloading) ;;
+              *)
+                echo "[sichek] service state='${state:-unknown}', restarting"
+                $HOST sichek d start
+                ;;
+            esac
             # Optionally restart tail if it dies, but tail -F is robust against recreation/rotation
             sleep 10
           done

--- a/k8s/devops_deploy.cuda128.yaml
+++ b/k8s/devops_deploy.cuda128.yaml
@@ -101,10 +101,18 @@ spec:
           TAIL_PID=$!
 
           while true; do
-            if ! $HOST systemctl is-active --quiet sichek; then
-              echo "[sichek] service not active, restarting"
-              $HOST sichek d start
-            fi
+            # Only restart when the unit is genuinely down. "activating" (a slow
+            # first start, e.g. nvidia-smi probing GPUs) and "active" are healthy,
+            # so we never kill an in-progress start; systemd TimeoutStartSec=300
+            # is the backstop for a truly stuck start.
+            state=$($HOST systemctl show -p ActiveState --value sichek 2>/dev/null || true)
+            case "$state" in
+              active|activating|reloading) ;;
+              *)
+                echo "[sichek] service state='${state:-unknown}', restarting"
+                $HOST sichek d start
+                ;;
+            esac
             # Optionally restart tail if it dies, but tail -F is robust against recreation/rotation
             sleep 10
           done

--- a/k8s/devops_deploy.yaml
+++ b/k8s/devops_deploy.yaml
@@ -99,10 +99,18 @@ spec:
           tail -n 100 -F /host/var/sichek/run/current/sichek.log &
           TAIL_PID=$!
           while true; do
-            if ! $HOST systemctl is-active --quiet sichek; then
-              echo "[sichek] service not active, restarting"
-              $HOST sichek d start
-            fi
+            # Only restart when the unit is genuinely down. "activating" (a slow
+            # first start, e.g. nvidia-smi probing GPUs) and "active" are healthy,
+            # so we never kill an in-progress start; systemd TimeoutStartSec=300
+            # is the backstop for a truly stuck start.
+            state=$($HOST systemctl show -p ActiveState --value sichek 2>/dev/null || true)
+            case "$state" in
+              active|activating|reloading) ;;
+              *)
+                echo "[sichek] service state='${state:-unknown}', restarting"
+                $HOST sichek d start
+                ;;
+            esac
             # Optionally restart tail if it dies, but tail -F is robust against recreation/rotation
             sleep 10
           done

--- a/pkg/utils/linux_test.go
+++ b/pkg/utils/linux_test.go
@@ -56,6 +56,34 @@ func TestExecCommandWithContext_Timeout(t *testing.T) {
 	}
 }
 
+// TestExecCommandWithContext_TimeoutKillsRunningProcess verifies that a
+// genuinely long-running command is killed when the context deadline fires and
+// that ExecCommand returns close to the deadline rather than waiting for the
+// command to finish on its own. This is the load-bearing property behind the
+// bounded nvidia-smi startup probe: a hung `nvidia-smi -q` must be terminated
+// at the probe timeout instead of blocking daemon startup indefinitely.
+func TestExecCommandWithContext_TimeoutKillsRunningProcess(t *testing.T) {
+	if IsRunningInKubernetes() {
+		t.Skip("skipping: ExecCommand routes through nsenter under Kubernetes")
+	}
+	const deadline = 300 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	start := time.Now()
+	// `sleep 10` would run far longer than the deadline if not killed.
+	_, err := ExecCommand(ctx, "sleep", "10")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	// Must return shortly after the deadline, not after the full sleep.
+	if elapsed > 3*time.Second {
+		t.Fatalf("ExecCommand did not return promptly after deadline: elapsed=%v (want <3s)", elapsed)
+	}
+}
+
 func TestExecCommandWithContext_CommandError(t *testing.T) {
 	ctx := context.Background()
 	command := "false" // `false` command always returns a non-zero exit status


### PR DESCRIPTION
正文：
## 问题
当节点 GPU 故障时(例如 NVLink Rx-detect 失败),`nvidia-smi -q` 会挂死。
此时 sichek daemon 永远到不了 systemd READY,DaemonSet 的 keepalive 便每 ~15s
重启它一次 —— 形成无限的 start/kill 循环(`ActiveState=activating`、
`NRestarts=0`,即所有重启都来自外部)。循环期间 daemon 什么都报不出来,坏卡
对运维完全不可见。

## 根因
NVIDIA collector 在 daemon「启动 → READY」的关键路径上执行 `nvidia-smi -q`
(`SoftwareInfo.Get`),而它只受共享的 30s `CmdTimeout` 约束。
`RestartSystemdService` 给 `systemctl restart` 套了 5s ctx,因此 keepalive 的
有效周期约为 ~15s(5s restart 客户端 + 10s sleep)。启动需 30s > 15s 周期 ⇒
daemon 每次都在 `activating` 阶段被逮到并杀掉。

## 改动
- **给探测加界**:为 `SoftwareInfo.Get` 循环引入专用的
  `NvidiaSWInfoProbeTimeout = 9s`,替换该路径上共享的 30s `CmdTimeout`。
- **独立的错误标识**:通过 sentinel 错误 `ErrSWInfoProbeTimeout`(用
  `errors.Is` 匹配)把这种「挂死」映射为专门的 `NvidiaSMITimeout` `ErrorName`
  (Critical),使自动恢复动作可据此识别,而不与通用的 `InitError` 冲突;其余
  init 失败仍报 `InitError`。
- **keepalive**:`k8s/deploy.yaml`、`devops_deploy.yaml`、
  `devops_deploy.cuda128.yaml` 现在仅在单元真正 failed/dead 时才重启,并容忍
  `active`/`activating` 状态(以 systemd `TimeoutStartSec=300` 兜底)。
- 测试:`TestExecCommandWithContext_TimeoutKillsRunningProcess`(ctx 到期确实
  会杀掉挂死的子进程)与 `TestCheckInitError_Classification`
  (sentinel→`NvidiaSMITimeout`、普通错误→`InitError`)。

## 自动恢复可用的钩子
- annotation:`"nvidia":{"critical":[{"error_name":"NvidiaSMITimeout",...}]}`
- Prometheus:`sichek_nvidia_nvidiasmitimeout`(原为 `sichek_nvidia_initerror`)