### PR TITLE
feat(transceiver): 采集 mlxlink -c 的 BER/物理计数器并上报

### DIFF
--- a/components/transceiver/collector/mlxlink_dom.go
+++ b/components/transceiver/collector/mlxlink_dom.go
@@ -27,7 +27,9 @@ func CollectMLXLink(ctx context.Context, dev string) (ModuleInfo, error) {
 	cmdCtx, cancel := context.WithTimeout(ctx, consts.CmdTimeout)
 	defer cancel()
 
-	output, err := utils.ExecCommand(cmdCtx, "mlxlink", "-d", dev, "-m")
+	// -m: module DOM data; -c: physical counters and BER. Both sections print
+	// in one invocation and are parsed independently below.
+	output, err := utils.ExecCommand(cmdCtx, "mlxlink", "-d", dev, "-m", "-c")
 	if err != nil {
 		outputStr := string(output)
 		if strings.Contains(err.Error(), "No cable") || strings.Contains(outputStr, "No cable") ||
@@ -38,6 +40,7 @@ func CollectMLXLink(ctx context.Context, dev string) (ModuleInfo, error) {
 	}
 
 	module.parseMLXLink(string(output))
+	module.parseMLXLinkCounters(string(output))
 	return module, nil
 }
 
@@ -116,6 +119,67 @@ func (m *ModuleInfo) parseMLXLink(output string) {
 			m.TxPowerHighAlarm = high
 		}
 	}
+}
+
+// parseMLXLinkCounters parses the "Physical Counters and BER Info" section
+// emitted by `mlxlink -c`. Example (values are ANSI-colored on a terminal):
+//
+//	Time Since Last Clear [Min]        : 348349.5
+//	Effective Physical Errors          : 0
+//	Effective Physical BER             : 15E-255
+//	Link Down Counter                  : 0
+//	Link Error Recovery Counter        : 0
+//	Raw Physical BER                   : 2E-9
+//
+// Keys are matched exactly so "Effective Physical BER" does not collide with
+// "Effective Physical Errors", nor "Raw Physical BER" with "Raw Physical
+// Errors Per Lane" (the per-lane array is intentionally not collected).
+func (m *ModuleInfo) parseMLXLinkCounters(output string) {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		kv := strings.SplitN(line, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val := stripANSI(kv[1])
+
+		switch key {
+		case "Raw Physical BER":
+			m.RawPhysicalBER = parseMLXLinkBER(val)
+		case "Effective Physical BER":
+			m.EffectivePhysicalBER = parseMLXLinkBER(val)
+		case "Effective Physical Errors":
+			m.EffectivePhysicalErrors = parseMLXLinkUint(val)
+		case "Link Down Counter":
+			m.LinkDownCounter = parseMLXLinkUint(val)
+		case "Link Error Recovery Counter":
+			m.LinkErrorRecoveryCounter = parseMLXLinkUint(val)
+		case "Time Since Last Clear [Min]":
+			m.TimeSinceLastClearMin = parseMLXLinkBER(val)
+		}
+	}
+}
+
+// parseMLXLinkBER parses a possibly scientific-notation float such as "2E-9" or
+// "15E-255". The regex-based parseFloat helper stops at the exponent, so BER and
+// time values must go through strconv directly. Returns 0 on failure (e.g. "N/A").
+func parseMLXLinkBER(s string) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// parseMLXLinkUint parses a decimal counter, returning 0 on failure (e.g. "N/A").
+func parseMLXLinkUint(s string) uint64 {
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }
 
 // parseMLXLinkValueWithRange parses "54 [-5..75]" → value=54, low=-5, high=75

--- a/components/transceiver/collector/mlxlink_dom_test.go
+++ b/components/transceiver/collector/mlxlink_dom_test.go
@@ -42,6 +42,104 @@ const mlxlinkSampleHealthyRecommendation = "\n" +
 	"--------------------\n" +
 	"Recommendation                     : No issue was observed\n"
 
+// mlxlinkCountersSample mirrors the "Physical Counters and BER Info" section
+// emitted by `mlxlink -d <dev> -c` on a healthy 400G link (captured on clnet36
+// mlx5_1). mlxlink colorizes the values green on a terminal, so the BER values
+// carry ANSI codes here to exercise the stripANSI path.
+const mlxlinkCountersSample = "\n" +
+	"Physical Counters and BER Info\n" +
+	"------------------------------\n" +
+	"Time Since Last Clear [Min]        : 348349.5\n" +
+	"Effective Physical Errors          : 0\n" +
+	"Effective Physical BER             : \x1b[32m15E-255\x1b[0m\n" +
+	"Raw Physical Errors Per Lane       : 3946476397,5120336064,7692183445,3026261414\n" +
+	"Link Down Counter                  : 0\n" +
+	"Link Error Recovery Counter        : 0\n" +
+	"Raw Physical BER                   : \x1b[32m2E-9\x1b[0m\n"
+
+// mlxlinkCountersDegradedSample is a synthetic degraded link: FEC no longer
+// masks all errors (non-zero Effective errors/BER) and the link has flapped.
+const mlxlinkCountersDegradedSample = "\n" +
+	"Physical Counters and BER Info\n" +
+	"------------------------------\n" +
+	"Time Since Last Clear [Min]        : 120.0\n" +
+	"Effective Physical Errors          : 42\n" +
+	"Effective Physical BER             : 1E-12\n" +
+	"Link Down Counter                  : 3\n" +
+	"Link Error Recovery Counter        : 7\n" +
+	"Raw Physical BER                   : 5E-8\n"
+
+func TestParseMLXLinkCounters(t *testing.T) {
+	t.Run("healthy counters with ANSI-colored BER", func(t *testing.T) {
+		m := &ModuleInfo{}
+		m.parseMLXLinkCounters(mlxlinkCountersSample)
+		assert.Equal(t, uint64(0), m.EffectivePhysicalErrors)
+		assert.Equal(t, uint64(0), m.LinkDownCounter)
+		assert.Equal(t, uint64(0), m.LinkErrorRecoveryCounter)
+		assert.InDelta(t, 2e-9, m.RawPhysicalBER, 1e-18)
+		assert.InDelta(t, 348349.5, m.TimeSinceLastClearMin, 1e-6)
+		// 15E-255 ≈ 0 (FEC nulls it out) but is representable in float64.
+		assert.GreaterOrEqual(t, m.EffectivePhysicalBER, 0.0)
+		assert.Less(t, m.EffectivePhysicalBER, 1e-100)
+	})
+
+	t.Run("degraded counters parse non-zero", func(t *testing.T) {
+		m := &ModuleInfo{}
+		m.parseMLXLinkCounters(mlxlinkCountersDegradedSample)
+		assert.Equal(t, uint64(42), m.EffectivePhysicalErrors)
+		assert.Equal(t, uint64(3), m.LinkDownCounter)
+		assert.Equal(t, uint64(7), m.LinkErrorRecoveryCounter)
+		assert.InDelta(t, 1e-12, m.EffectivePhysicalBER, 1e-20)
+		assert.InDelta(t, 5e-8, m.RawPhysicalBER, 1e-16)
+		assert.InDelta(t, 120.0, m.TimeSinceLastClearMin, 1e-6)
+	})
+
+	t.Run("DOM-only output leaves counters zero", func(t *testing.T) {
+		m := &ModuleInfo{}
+		m.parseMLXLinkCounters(mlxlinkSampleOutput)
+		assert.Equal(t, uint64(0), m.EffectivePhysicalErrors)
+		assert.Equal(t, uint64(0), m.LinkDownCounter)
+		assert.InDelta(t, 0.0, m.RawPhysicalBER, 1e-18)
+	})
+}
+
+func TestParseMLXLinkBER(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"2E-9", 2e-9},
+		{"15E-255", 15e-255},
+		{"1E-12", 1e-12},
+		{"0", 0},
+		{"N/A", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.InDelta(t, tt.want, parseMLXLinkBER(tt.input), tt.want*1e-6+1e-300)
+		})
+	}
+}
+
+func TestParseMLXLinkUint(t *testing.T) {
+	tests := []struct {
+		input string
+		want  uint64
+	}{
+		{"0", 0},
+		{"42", 42},
+		{"3946476397", 3946476397},
+		{"N/A", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseMLXLinkUint(tt.input))
+		})
+	}
+}
+
 func TestParseMLXLinkRecommendation(t *testing.T) {
 	t.Run("bad signal integrity with ANSI color codes", func(t *testing.T) {
 		m := &ModuleInfo{}

--- a/components/transceiver/collector/transceiver_info.go
+++ b/components/transceiver/collector/transceiver_info.go
@@ -51,6 +51,18 @@ type ModuleInfo struct {
 	VoltageLowAlarm  float64 `json:"voltage_low_alarm_v"`
 
 	LinkErrors map[string]uint64 `json:"link_errors"`
+
+	// Physical-layer counters and BER from `mlxlink -c` (IB / mlx5-BDF path only;
+	// pure-ethtool interfaces leave these zero). All counters are cumulative since
+	// TimeSinceLastClearMin, so downstream consumers must interpret them as deltas.
+	// RawPhysicalBER is pre-FEC (a leading indicator); EffectivePhysicalBER/Errors
+	// are post-FEC (non-zero means FEC can no longer mask the damage).
+	RawPhysicalBER           float64 `json:"raw_physical_ber"`
+	EffectivePhysicalBER     float64 `json:"effective_physical_ber"`
+	EffectivePhysicalErrors  uint64  `json:"effective_physical_errors"`
+	LinkDownCounter          uint64  `json:"link_down_counter"`
+	LinkErrorRecoveryCounter uint64  `json:"link_error_recovery_counter"`
+	TimeSinceLastClearMin    float64 `json:"time_since_last_clear_min"`
 }
 
 type collectTask struct {

--- a/metrics/transceiver_counters_test.go
+++ b/metrics/transceiver_counters_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scitix/sichek/components/transceiver/collector"
+)
+
+// TestStructToMetricsMap_TransceiverCounters pins the reflection-driven export of
+// the new mlxlink -c physical counters / BER fields on ModuleInfo. TransceiverMetrics
+// exports these gauges as sichek_transceiver_module_<json-tag> purely by walking
+// json tags, so a rename of any tag would silently rename (or drop) the metric —
+// this asserts the exact names and values a populated module produces.
+func TestStructToMetricsMap_TransceiverCounters(t *testing.T) {
+	mod := collector.ModuleInfo{
+		RawPhysicalBER:           2e-9,
+		EffectivePhysicalBER:     1e-12,
+		EffectivePhysicalErrors:  42,
+		LinkDownCounter:          3,
+		LinkErrorRecoveryCounter: 7,
+		TimeSinceLastClearMin:    120.5,
+	}
+
+	got := map[string]*StructMetrics{}
+	StructToMetricsMap(reflect.ValueOf(mod), "", "json", got)
+
+	// metric-name (json tag) → expected gauge value
+	want := map[string]float64{
+		"raw_physical_ber":            2e-9,
+		"effective_physical_ber":      1e-12,
+		"effective_physical_errors":   42,
+		"link_down_counter":           3,
+		"link_error_recovery_counter": 7,
+		"time_since_last_clear_min":   120.5,
+	}
+
+	for name, exp := range want {
+		sm, ok := got[name]
+		if assert.Truef(t, ok, "metric %q must be exported from ModuleInfo json tags", name) {
+			assert.InDelta(t, exp, sm.MetricsValue, exp*1e-6+1e-300)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

`transceiver` 组件此前只跑 `mlxlink -d <dev> -m`，采集 DOM（温度/电压/收发光功率）。
物理层误码相关指标——高网工程师点名的 **误码率(BER) / 链路断开数 / 有效错误计数**
——来自 `mlxlink -c` 的 "Physical Counters and BER Info" 段，之前**完全没采集**。

结果是 `check_signal_integrity` 只能靠 mlxlink 的 Recommendation 文字判断信号完整性，
拿不到量化 BER：一条链路 Raw BER 在爬升、FEC 还扛得住时，当前 sichek 抓不到这个
掉卡前最灵敏的前哨信号。

## 改动

在现有 `-m` 命令上加 `-c`（一次调用拿两段），新增 `parseMLXLinkCounters` 解析计数器段，
往 `ModuleInfo` 加 6 个带 json tag 的标量字段。这些字段经 `StructToMetricsMap` 反射
**自动**导出到 snapshot + Prometheus，无需手写 gauge：

| 指标 (`sichek_transceiver_module_*`) | 含义 |
|---|---|
| `raw_physical_ber` | FEC 纠错前误码率（前哨/趋势） |
| `effective_physical_ber` | FEC 纠错后残余误码率 |
| `effective_physical_errors` | 纠错后残余错误数 |
| `link_down_counter` | 链路彻底断次数 |
| `link_error_recovery_counter` | 链路错误恢复次数（断链前兆） |
| `time_since_last_clear_min` | 计数器清零基准（累计值解释用） |

label：`interface` / `network_type` / `node`。

**本轮只做指标上报，不加 checker / 级别判定 / 去抖锁存**（后续单独跟进）。

## 实现要点

- **BER 解析**：`2E-9`/`15E-255` 用 `strconv.ParseFloat` 直接解析——既有的 regex 版
  `parseFloat` 遇科学计数法会在指数处截断，不能复用。
- **精确 key 匹配**：`"Raw Physical BER"` 不会误吞 `"Raw Physical BER Per Lane"` 变体
  （thg1 实证），`"Effective Physical BER"` 也与 `"Effective Physical Errors"` 区分。
- **覆盖范围**：只走 mlxlink 路径（IB + mlx5-BDF/RoCE）。BF3 的 `-c` 不输出 Link Down /
  Link Error Recovery 两行、纯 ethtool netdev 无 BER —— 这些字段优雅降级为 0，不误报。

## 测试

- 单测：`parseMLXLinkCounters` 表驱动（真机 fixture + 健康/劣化两组）+ BER/uint 辅助函数 +
  反射导出命名/值断言（不碰全局 prometheus 注册表）。
- `go test ./components/transceiver/... ./metrics/...` PASS，`go vet` clean，`go build ./...` PASS。

## 现场回归（2026-08-18，全矩阵 9 节点 PASS，零 panic）

| 节点 | 拓扑 | 结果 |
|---|---|---|
| clnet36 | 64 mlx5 SR-IOV | 6 gauge 全出，eth0 raw_ber=`1e-8` = 探针值 ✓ |
| bjg45 | mlx5_0..8 | ib0 raw_ber=`9e-11` = 探针值 ✓ |
| thg1 | mlx5+mezz | mezz 正确排除；`Per Lane` 变体正确忽略 |
| lmg86 / lmg104 | BF3 | Link Down/Recovery 缺行→优雅降级 0 |
| dracog24 | CX6 | ib0 raw_ber=`1e-7` = 探针值 ✓ |
| bjg66 | 信号完整性节点 | mlx5_8 raw_ber 偏高但 FEC 掩盖 |
| shg06 / shg205 | 无 mlxlink | 不崩，字段=0 / 0 模块 |