### PR TITLE
fix(transceiver): 给 CLI 独立 120s 超时并跳过 mezzanine 口

### DIFF
--- a/cmd/command/component/transceiver.go
+++ b/cmd/command/component/transceiver.go
@@ -39,17 +39,10 @@ func NewTransceiverCmd() *cobra.Command {
 		Aliases: []string{"tr"},
 		Short:   "Perform Transceiver HealthCheck",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, cancel := context.WithTimeout(context.Background(), consts.CmdTimeout)
-
 			if !verbose {
 				logrus.SetLevel(logrus.ErrorLevel)
-				defer cancel()
 			} else {
 				logrus.SetLevel(logrus.DebugLevel)
-				defer func() {
-					logrus.WithField("component", "transceiver").Info("Run transceiver Cmd context canceled")
-					cancel()
-				}()
 			}
 
 			resolvedCfgFile, err := spec.EnsureCfgFile(cfgFile)
@@ -75,8 +68,23 @@ func NewTransceiverCmd() *cobra.Command {
 				logrus.WithField("component", "transceiver").Error(err)
 				return
 			}
+			// Start the health-check budget only now that config, spec and the
+			// component are resolved. Those steps fetch from OSS, and on a node with
+			// no route to it each attempt blocks until its own timeout — roughly 14s
+			// in total when measured. Counting that against the collection budget
+			// left the collector ~16s of its 30s and made it time out with no data.
+			ctx, cancel := context.WithTimeout(context.Background(), consts.TransceiverCmdTimeout)
+			if verbose {
+				defer func() {
+					logrus.WithField("component", "transceiver").Info("Run transceiver Cmd context canceled")
+					cancel()
+				}()
+			} else {
+				defer cancel()
+			}
+
 			logrus.WithField("component", "transceiver").Infof("Run Transceiver component check: %s", component.Name())
-			result, err := RunComponentCheck(ctx, component, consts.CmdTimeout)
+			result, err := RunComponentCheck(ctx, component, consts.TransceiverCmdTimeout)
 			if err != nil {
 				return
 			}

--- a/components/transceiver/collector/utils.go
+++ b/components/transceiver/collector/utils.go
@@ -17,6 +17,22 @@ type InterfaceEntry struct {
 	PcieBDF  string // PCIe BDF address for mlxlink -d
 }
 
+// isMezzanine reports whether a name belongs to a mezzanine card. The naming
+// differs per platform — netdev "mezz0" and IB device "mezz_0" on one, "mezz_0"
+// for both on another — so this matches the substring, consistent with how the
+// infiniband, hca and perftest packages already exclude these devices.
+//
+// Mezzanine ports are board-level InfiniBand links with no pluggable optics, so
+// there is no transceiver to read: their netdev is IPoIB, where `ethtool -m`
+// returns "Operation not supported", and `mlxlink -m` either reports every module
+// field as N/A, fails on a firmware ICMD error, or segfaults outright depending
+// on the board. Collecting them yields nothing but empty module rows — which look
+// like a module with no vendor and 0 °C to the checkers — while costing one slow
+// mlxlink invocation per port.
+func isMezzanine(name string) bool {
+	return strings.Contains(name, "mezz")
+}
+
 func EnumerateTransceiverInterfaces() ([]InterfaceEntry, error) {
 	var entries []InterfaceEntry
 
@@ -31,6 +47,10 @@ func EnumerateTransceiverInterfaces() ([]InterfaceEntry, error) {
 		if name == "lo" || name == "bonding_masters" ||
 			strings.HasPrefix(name, "veth") || strings.HasPrefix(name, "docker") ||
 			strings.HasPrefix(name, "br-") || strings.HasPrefix(name, "virbr") {
+			continue
+		}
+		// Skip mezzanine ports — no pluggable transceiver to read.
+		if isMezzanine(name) {
 			continue
 		}
 		// Skip VLAN sub-interfaces (e.g. eth0.10, eth1.2)
@@ -78,6 +98,11 @@ func EnumerateTransceiverInterfaces() ([]InterfaceEntry, error) {
 	}
 	for _, e := range ibEntries {
 		ibDev := e.Name()
+		// Skip mezzanine ports here too: they are enumerated as IB devices
+		// ("mezz_0"), which is the path that would otherwise reach mlxlink.
+		if isMezzanine(ibDev) {
+			continue
+		}
 		physfn := filepath.Join(ibDir, ibDev, "device", "physfn")
 		if _, err := os.Stat(physfn); err == nil {
 			continue

--- a/components/transceiver/collector/utils_test.go
+++ b/components/transceiver/collector/utils_test.go
@@ -6,6 +6,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsMezzanine(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Netdev and IB spellings seen in the field: "mezz0"/"mezz_0" on a
+		// multi-plane B300 host, "mezz_0" for both netdev and IB device on thg1.
+		{name: "mezz0", want: true},
+		{name: "mezz3", want: true},
+		{name: "mezz_0", want: true},
+		{name: "mezz_3", want: true},
+		// Substring match, matching how the other packages exclude mezzanine cards.
+		{name: "bond_mezz0", want: true},
+		// Real transceiver-bearing interfaces must not be caught.
+		{name: "eth_r0_p0", want: false},
+		{name: "roce_r0", want: false},
+		{name: "mlx5_0", want: false},
+		{name: "ib0", want: false},
+		{name: "mgmt0", want: false},
+		{name: "eth0", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isMezzanine(tt.name))
+		})
+	}
+}
+
 func newTestClassifier() *NetworkClassifier {
 	return NewNetworkClassifier(
 		map[string][]string{

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -176,6 +176,18 @@ func LevelColor(level string) string {
 const PadLen = len(Green) + len(Reset)
 const CmdTimeout = 30 * time.Second
 
+// TransceiverCmdTimeout bounds a one-shot `sichek transceiver` run. It is larger
+// than CmdTimeout because DOM data comes from mlxlink, which costs roughly a
+// second per port and serializes on an MFT-wide lock, so the sweep scales with
+// port count rather than running concurrently. A multi-plane node exposes each
+// rail NIC as four PCIe functions: measured end to end at ~48s for 34 ports
+// while the daemon was sweeping the same devices, which does not fit in 30s and
+// used to surface as a bogus "transceiver: FAIL" with no data at all.
+//
+// It is deliberately a separate constant rather than a bump to CmdTimeout, which
+// every other component shares and none of them need widened.
+const TransceiverCmdTimeout = 120 * time.Second
+
 // NvidiaSWInfoProbeTimeout bounds the `nvidia-smi -q` driver/CUDA-version probe
 // run during NVIDIA collector initialization so a hung nvidia-smi (e.g. an
 // NVLink fault stalling the query path) cannot block daemon startup for the full


### PR DESCRIPTION
多 plane 机型(每张轨卡暴露 4 个 PCIe function)上 `sichek transceiver` 稳定报 "No transceiver info available" + FAIL。这是采集超时被当成了健康 失败:DOM 数据来自 mlxlink,每口约 1s 且在 MFT 全局锁上串行,一台
34~38 口的机器需要 60~75s,远超共享的 30s CmdTimeout。

超时的表现之所以是"无数据"而不是"超时",是因为 RunHealthCheckWithTimeout 走 ctx.Done() 分支时 createTimeoutResult 返回的 err 为 nil,调用方继续 执行,但 HealthCheck goroutine 仍阻塞在 Collect、cacheInfo 从未写入, 于是 LastInfo() 返回 nil,PrintInfo 的类型断言失败。

三处改动:

1. 新增 consts.TransceiverCmdTimeout = 120s。刻意与 CmdTimeout 分开, 后者为所有组件共用,其余组件都不需要放宽。

2. ctx 创建从 Run 首行挪到组件构建之后。EnsureCfgFile/EnsureSpecFile 会访问 OSS,节点不通时两次拉取合计约 14s,原先这段时间计入采集预算, 只给采集留下约 16s。放在 NewComponent 之后是因为它内部也有 spec 下载分支。

3. 枚举阶段跳过 mezzanine 口。它们是板级 IB 链路,没有可插拔光模块: netdev 为 IPoIB,ethtool -m 返回 Operation not supported;mlxlink -m 视板型分别返回全 N/A、固件 ICMD 报错,或直接 SIGSEGV(thg1 上四个 mezz 全部 exit 139,内核日志有对应 mlxlink_ext segfault)。采集它们 只会产出无 vendor、0°C 的空模块行,还要为每口付一次慢速 mlxlink 调用。 命名按平台不同(B300 上 netdev mezz0 / IB device mezz_0,thg1 上两者 都是 mezz_0),故按子串匹配,与 infiniband、hca、perftest 各包既有的 strings.Contains(name, "mezz") 保持一致。

本次只改 CLI 路径。daemon 的超时取自 query_interval,未受影响。

现场回归 6 台(2026-08-25):两台 B300 由 FAIL 转 PASS;thg1(4 个 mezz) 与 clnet36/lmg86/dracog24(无 mezz)行数逐一不变;daemon 指标序列数与 CLI 行数一致;无新增单元测试失败。