### PR TITLE
fix(systemd): order sichek after openibd/rdma-env-pre/network-online

### DIFF
--- a/config/default_user_config.yaml
+++ b/config/default_user_config.yaml
@@ -7,7 +7,7 @@ snapshot:
 
 reporter:
   enable: false  # master switch; flip to true after deploying sichek-collector
-  endpoint: "http://sichek-collector.monitoring.svc:38080/api/v1/snapshots"
+  endpoint: "http://10.155.30.38:38080/api/v1/snapshots"
   interval: 60s
   timeout: 30s
   retry_max: 3
@@ -86,16 +86,16 @@ nccltest:
 #   enable_metrics: true
 
 transceiver:
-  query_interval: 30s
+  query_interval: 300s
   cache_size: 5
   ignored_checkers: []
   enable_metrics: true
 
-# lldp:
-#   query_interval: 5m
-#   cache_size: 5
-#   lldpctl_path: ""        # leave empty to resolve from $PATH
-#   exec_timeout: 10s
+lldp:
+  query_interval: 5m
+  cache_size: 5
+  lldpctl_path: ""        # leave empty to resolve from $PATH
+  exec_timeout: 10s
 
 sysinfo:
   enable: true

--- a/systemd/sichek.service
+++ b/systemd/sichek.service
@@ -1,8 +1,33 @@
 [Unit]
 Description=sichek
 
-Wants=network-pre.target
-After=network-pre.target NetworkManager.service systemd-resolved.service
+Wants=network-pre.target network-online.target
+# Ordered after the units that finish bringing the NIC up, so the IB checkers do
+# not read a half-initialized stack and misreport it. Each target fixes a class
+# of boot-race false positive:
+#   - openibd.service       : the mlx5 driver populates /sys/class/infiniband here.
+#                             Before it, the IB collector sees zero devices and every
+#                             IB checker reports NOIBFOUND; mid-probe a PF is on the
+#                             PCI bus with no infiniband/ or net/ yet and IBLost flags
+#                             it as a phantom card.
+#   - rdma-env-pre.service  : does eswitch/vf-config/interface-naming/roce-ar, i.e.
+#                             brings ports to LinkUp and enumerates all PFs/VFs. Before
+#                             it, phys_state is still Polling (PhyState "NOT LinkUp")
+#                             and the device/rail count is short (odd rail count ->
+#                             Critical). It is itself After=openibd and waits for the
+#                             IB devices, so ordering after it also covers the driver.
+#   - network-online.target : bond0 is up with an IP here, for the ethernet/L3/RoCE
+#                             connectivity checks.
+# openibd/rdma-env-pre are PURE ordering (no Wants/Requires): sichek ships fleet-wide,
+# and on a host without them an After= on an absent unit is simply ignored. This only
+# fixes the BOOT race; the resident daemon's periodic re-checks still need in-checker
+# readiness gating to tell "not ready yet" from "broken".
+#
+# It also keeps sichek off init's back while init runs: rdma-env-pre.service is
+# Type=oneshot+RemainAfterExit=yes, so this After= holds sichek until init reaches
+# active(exited) or failed -- never forever -- and sichek's per-NIC mlxlink/mlxreg
+# fleet stops contending with init's mlxconfig/MFT tools.
+After=network-pre.target NetworkManager.service systemd-resolved.service openibd.service rdma-env-pre.service network-online.target
 
 [Service]
 Slice=runtime.slice


### PR DESCRIPTION
## 问题
sichek 的 IB checker 在采集时刻直接读 `/sys/class/infiniband/...`,把"网卡还没初始化完"当成"坏了"。当 sichek 在 RDMA 栈就绪前启动,会产生开机竞争误报:

- **NOIBFOUND** —— mlx5 驱动还没填好 `/sys/class/infiniband`(`nic_phy_state.go:71`、`fw.go:74`、`ib_kmod.go:74` 等 9 处)
- **PhyState "NOT LinkUp"** —— 端口还在 `Polling`(`nic_phy_state.go:98`)
- **odd rail count(Critical,可能 cordon 节点)** —— PF/VF 还没枚举齐(`ib_rail_count.go:207`)
- **IBLost "phantom HCA"** —— probe 中途,PF 在 PCI 总线但还没建出 `infiniband/`、`net/`(`ib_lost.go:77`、`pcie_info.go:183`)

## 改动
把 unit 排到"真正把网卡初始化好"的单元之后,让 checker 观测到已收敛的栈:

| After 新增 | 作用 |
|---|---|
| `openibd.service` | 填充 `/sys/class/infiniband` → 消 NOIBFOUND / IBLost probe 竞争 |
| `rdma-env-pre.service` | 做 eswitch/vf-config/interface-naming/roce-ar,端口拉 LinkUp、枚举 PF/VF → 消 PhyState / rail-count;自身 `After=openibd`,顺带覆盖驱动就绪;并让 sichek 的 mlxlink/mlxreg 不再和 init 的 mlxconfig/MFT 争抢 |
| `network-online.target` | bond0 起、IP 配好 → 给 ethernet/L3/RoCE 连通性检查用(`Wants=`+`After=`) |

`openibd` / `rdma-env-pre` 为**纯 `After=`**(不加 Requires),缺失即忽略,对全 fleet 安全。

## 范围与已知限制
- 只改 `systemd/sichek.service`(go:embed 源头,`sichek d start/update` 会覆盖写 `/etc/systemd/system/sichek.service`)。
- **只治开机竞争**;常驻 daemon 的周期性复检仍会误报,根因修复需在 checker 层加"就绪门"(区分"还没好"与"坏了"),后续单独提。
- `network-online.target` 采用软依赖(`Wants`+`After`):网络起不来时 sichek 最多被 wait-online 超时拖 ~1–2min(仅开机),之后照常启动,不会失败或永久阻塞。