### PR TITLE
feat(snapshot): 采集节点 boot_time/uptime_seconds,并修复 -inf 冻结整份 snapshot 的 bug

### DIFF
--- a/components/transceiver/collector/ethtool_dom.go
+++ b/components/transceiver/collector/ethtool_dom.go
@@ -124,8 +124,7 @@ func parseDBM(s string) float64 {
 			part = strings.TrimSpace(part[slashIdx+1:])
 		}
 		val, _ := strconv.ParseFloat(strings.TrimSpace(part), 64)
-		return val
+		return finiteOrZero(val)
 	}
 	return parseFloat(s)
 }
-

--- a/components/transceiver/collector/finite_guard_test.go
+++ b/components/transceiver/collector/finite_guard_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package collector
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFiniteOrZero(t *testing.T) {
+	assert.Equal(t, 0.0, finiteOrZero(math.Inf(1)))
+	assert.Equal(t, 0.0, finiteOrZero(math.Inf(-1)))
+	assert.Equal(t, 0.0, finiteOrZero(math.NaN()))
+	assert.Equal(t, -1.5, finiteOrZero(-1.5))
+	assert.Equal(t, 0.0, finiteOrZero(0.0))
+}
+
+// A dark / unconnected optical lane reports "-inf dBm"; strconv.ParseFloat
+// accepts "-inf" as a valid float, so without the guard the power reading would
+// be -Inf and later break the whole snapshot's JSON marshal.
+func TestParseDBM_NonFinite(t *testing.T) {
+	assert.Equal(t, 0.0, parseDBM("-inf dBm"))
+	assert.Equal(t, 0.0, parseDBM("inf dBm"))
+	// Normal readings still parse, including the "high/low" slash form.
+	assert.Equal(t, -1.5, parseDBM("-1.5 dBm"))
+	assert.Equal(t, -2.3, parseDBM("-40.0 / -2.3 dBm"))
+}
+
+func TestParseMLXLinkBER_NonFinite(t *testing.T) {
+	assert.Equal(t, 0.0, parseMLXLinkBER("-inf"))
+	assert.Equal(t, 0.0, parseMLXLinkBER("inf"))
+	assert.Equal(t, 0.0, parseMLXLinkBER("nan"))
+	assert.Equal(t, 0.0, parseMLXLinkBER("N/A"))
+	// Scientific-notation BER values still parse.
+	assert.InDelta(t, 2e-9, parseMLXLinkBER("2E-9"), 1e-20)
+	assert.InDelta(t, 15e-255, parseMLXLinkBER("15E-255"), 1e-260)
+}
+
+func TestParseMLXLinkMultiLane_NonFinite(t *testing.T) {
+	// A lane reporting -inf is normalized to 0 while finite lanes are kept.
+	got := parseMLXLinkMultiLane("-inf,8.380,8.380 [2..15]")
+	assert.Equal(t, []float64{0, 8.380, 8.380}, got)
+}

--- a/components/transceiver/collector/mlxlink_dom.go
+++ b/components/transceiver/collector/mlxlink_dom.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -10,6 +11,20 @@ import (
 	"github.com/scitix/sichek/consts"
 	"github.com/scitix/sichek/pkg/utils"
 )
+
+// finiteOrZero returns 0 when v is not a finite number. strconv.ParseFloat
+// accepts "inf"/"-inf"/"nan" (case-insensitive) as valid input, so a DOM power
+// reading of "-inf dBm" (a dark / unconnected lane) or a non-finite BER parses
+// to a non-finite float64. Such a value later makes encoding/json reject the
+// entire snapshot ("json: unsupported value: -Inf"), which silently freezes
+// snapshot.json on every node with an unlit lane. Normalizing to 0 keeps the
+// data JSON-serializable; 0 is a harmless sentinel for "no signal".
+func finiteOrZero(v float64) float64 {
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return 0
+	}
+	return v
+}
 
 // ansiEscapeRe matches ANSI SGR color/style escape sequences (e.g. "\x1b[31m").
 var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
@@ -170,7 +185,7 @@ func parseMLXLinkBER(s string) float64 {
 	if err != nil {
 		return 0
 	}
-	return v
+	return finiteOrZero(v)
 }
 
 // parseMLXLinkUint parses a decimal counter, returning 0 on failure (e.g. "N/A").
@@ -229,7 +244,7 @@ func parseMLXLinkMultiLane(s string) []float64 {
 		if err != nil {
 			continue
 		}
-		values = append(values, v)
+		values = append(values, finiteOrZero(v))
 	}
 	return values
 }

--- a/pkg/utils/linux.go
+++ b/pkg/utils/linux.go
@@ -54,6 +54,42 @@ func GetMgmtIP() string {
 	return ""
 }
 
+// parseUptime extracts the seconds-since-boot value (the first field) from the
+// contents of /proc/uptime. The file holds two space-separated floats: uptime
+// and idle time; we only need the first.
+func parseUptime(content string) (float64, error) {
+	fields := strings.Fields(content)
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("empty /proc/uptime content")
+	}
+	secs, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse uptime %q: %w", fields[0], err)
+	}
+	return secs, nil
+}
+
+// GetUptime returns the node's uptime in seconds by reading /proc/uptime.
+// /proc/uptime is not isolated by the PID namespace, so a container reads the
+// host's value directly — no nsenter required. Returns (0, err) on failure.
+func GetUptime() (float64, error) {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/uptime: %w", err)
+	}
+	return parseUptime(string(data))
+}
+
+// GetBootTime returns the node's boot instant, computed as now - uptime.
+// Returns a zero time.Time (and the error) when the uptime cannot be read.
+func GetBootTime() (time.Time, error) {
+	uptime, err := GetUptime()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Now().Add(-time.Duration(uptime * float64(time.Second))), nil
+}
+
 func IsRoot() bool {
 	return os.Geteuid() == 0
 }
@@ -197,4 +233,3 @@ func IsLowSpeedIBBond(ibDev string) bool {
 	}
 	return false
 }
-

--- a/pkg/utils/linux_test.go
+++ b/pkg/utils/linux_test.go
@@ -132,3 +132,66 @@ func TestExecCommandWithContext_OfedInfo(t *testing.T) {
 // 		}
 // 	}
 // }
+
+func TestParseUptime(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    float64
+		wantErr bool
+	}{
+		{name: "normal", content: "12345.67 98765.43\n", want: 12345.67},
+		{name: "single field", content: "42.0", want: 42.0},
+		{name: "leading spaces", content: "   7.5   1.2\n", want: 7.5},
+		{name: "empty", content: "", wantErr: true},
+		{name: "whitespace only", content: "   \n", wantErr: true},
+		{name: "non-numeric", content: "abc def", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUptime(tt.content)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value %v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseUptime(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetUptime(t *testing.T) {
+	uptime, err := GetUptime()
+	if err != nil {
+		t.Fatalf("GetUptime() error: %v", err)
+	}
+	if uptime <= 0 {
+		t.Fatalf("GetUptime() = %v, want > 0", uptime)
+	}
+}
+
+func TestGetBootTime(t *testing.T) {
+	before := time.Now()
+	boot, err := GetBootTime()
+	if err != nil {
+		t.Fatalf("GetBootTime() error: %v", err)
+	}
+	if !boot.Before(before) {
+		t.Fatalf("GetBootTime() = %v, want a time in the past (before %v)", boot, before)
+	}
+	// boot ≈ now - uptime; cross-check against a fresh uptime read within a few seconds.
+	uptime, err := GetUptime()
+	if err != nil {
+		t.Fatalf("GetUptime() error: %v", err)
+	}
+	expected := time.Now().Add(-time.Duration(uptime * float64(time.Second)))
+	if diff := boot.Sub(expected); diff > 5*time.Second || diff < -5*time.Second {
+		t.Fatalf("GetBootTime() = %v, want ≈ %v (diff %v)", boot, expected, diff)
+	}
+}

--- a/service/snapshot.go
+++ b/service/snapshot.go
@@ -152,7 +152,19 @@ func (s *SnapshotManager) persist() error {
 
 	data, err := json.MarshalIndent(s.data, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal snapshot failed: %w", err)
+		// A component's Info may contain a non-finite float (Inf/NaN) — e.g. a
+		// transceiver lane reporting "-inf dBm" — which encoding/json rejects
+		// atomically, failing the marshal of the whole snapshot. Without a
+		// fallback this freezes snapshot.json indefinitely: every subsequent
+		// persist hits the same value and the file keeps its last-good content.
+		// Re-encode with each component marshaled independently so the offending
+		// one is replaced by a placeholder while node identity, uptime, issues,
+		// and every healthy component still persist.
+		logrus.WithField("service", "snapshot").Warnf("marshal snapshot failed (%v); retrying with per-component isolation", err)
+		data, err = s.marshalIsolatingBadComponents()
+		if err != nil {
+			return fmt.Errorf("marshal snapshot failed: %w", err)
+		}
 	}
 
 	dir := filepath.Dir(s.path)
@@ -171,4 +183,35 @@ func (s *SnapshotManager) persist() error {
 	}
 
 	return nil
+}
+
+// marshalIsolatingBadComponents re-encodes the snapshot when a whole-snapshot
+// marshal failed. Each component is marshaled on its own; any that fails (e.g.
+// because it holds a non-finite float) is swapped for an error placeholder so
+// that a single bad component can no longer block the entire snapshot. All
+// other top-level fields (node, mgmt_ip, boot_time, uptime_seconds, timestamp,
+// issues) are preserved by embedding the original snapshot and shadowing only
+// its Components field.
+func (s *SnapshotManager) marshalIsolatingBadComponents() ([]byte, error) {
+	safeComponents := make(map[string]json.RawMessage, len(s.data.Components))
+	for name, info := range s.data.Components {
+		raw, err := json.Marshal(info)
+		if err != nil {
+			logrus.WithField("service", "snapshot").Warnf("component %q not JSON-serializable (%v); storing placeholder", name, err)
+			raw, _ = json.Marshal(map[string]string{"_snapshot_error": err.Error()})
+		}
+		safeComponents[name] = raw
+	}
+
+	// alias drops Snapshot's methods so the embedded value is marshaled as plain
+	// data; the outer Components field (depth 0) shadows the embedded one.
+	type alias Snapshot
+	envelope := struct {
+		*alias
+		Components map[string]json.RawMessage `json:"components"`
+	}{
+		alias:      (*alias)(s.data),
+		Components: safeComponents,
+	}
+	return json.MarshalIndent(envelope, "", "  ")
 }

--- a/service/snapshot.go
+++ b/service/snapshot.go
@@ -39,10 +39,16 @@ type SnapshotConfig struct {
 
 // Snapshot represents the aggregated data from all components.
 type Snapshot struct {
-	Node       string                 `json:"node"`
-	MgmtIP     string                 `json:"mgmt_ip,omitempty"`
-	Timestamp  time.Time              `json:"timestamp"`
-	Components map[string]interface{} `json:"components"`
+	Node   string `json:"node"`
+	MgmtIP string `json:"mgmt_ip,omitempty"`
+	// BootTime is the node's boot instant. It is stable for the life of the
+	// process, so it is computed once at startup.
+	BootTime time.Time `json:"boot_time,omitempty"`
+	// UptimeSeconds is the node's uptime in seconds, refreshed to the current
+	// value on every persist.
+	UptimeSeconds float64                `json:"uptime_seconds,omitempty"`
+	Timestamp     time.Time              `json:"timestamp"`
+	Components    map[string]interface{} `json:"components"`
 	// Issues mirrors the K8s node annotation: detected problems grouped by
 	// component then level. It lets the collector consume issues without reading
 	// the K8s annotation, and is populated even on non-K8s nodes.
@@ -73,6 +79,10 @@ func NewSnapshotManager(cfgFile string) (*SnapshotManager, error) {
 	}
 
 	hostname, _ := os.Hostname()
+	bootTime, err := utils.GetBootTime()
+	if err != nil {
+		logrus.WithField("service", "snapshot").Warnf("Failed to read boot time: %v", err)
+	}
 	mgr := &SnapshotManager{
 		path:     config.Snapshot.Path,
 		enabled:  config.Snapshot.Enable,
@@ -80,6 +90,7 @@ func NewSnapshotManager(cfgFile string) (*SnapshotManager, error) {
 		data: &Snapshot{
 			Node:       hostname,
 			MgmtIP:     utils.GetMgmtIP(),
+			BootTime:   bootTime,
 			Components: make(map[string]interface{}),
 		},
 	}
@@ -130,7 +141,15 @@ func (s *SnapshotManager) SetIssues(issues *nodeAnnotation) {
 }
 
 // persist writes the current snapshot to the local JSON file atomically.
+// It refreshes UptimeSeconds to the current value before marshaling; a read
+// failure leaves the previous value untouched rather than blocking the write.
 func (s *SnapshotManager) persist() error {
+	if uptime, err := utils.GetUptime(); err != nil {
+		logrus.WithField("service", "snapshot").Warnf("Failed to read uptime: %v", err)
+	} else {
+		s.data.UptimeSeconds = uptime
+	}
+
 	data, err := json.MarshalIndent(s.data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal snapshot failed: %w", err)

--- a/service/snapshot_test.go
+++ b/service/snapshot_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,17 @@ type MockInfo struct {
 }
 
 func (m *MockInfo) JSON() (string, error) {
+	data, err := json.Marshal(m)
+	return string(data), err
+}
+
+// nonFiniteInfo mimics a component (e.g. transceiver) whose Info carries a
+// non-finite float such as "-inf dBm", which encoding/json refuses to marshal.
+type nonFiniteInfo struct {
+	Power float64 `json:"power"`
+}
+
+func (m *nonFiniteInfo) JSON() (string, error) {
 	data, err := json.Marshal(m)
 	return string(data), err
 }
@@ -64,6 +76,44 @@ func TestSnapshotManager(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, snapshot.Components, "cpu")
 	assert.Contains(t, snapshot.Components, "nvidia")
+}
+
+// TestSnapshotManager_NonFiniteFloatIsolated verifies that a single component
+// carrying a non-finite float (Inf/NaN) can no longer freeze the whole snapshot:
+// the offending component is replaced by a placeholder while node identity,
+// uptime, and every healthy component still persist.
+func TestSnapshotManager_NonFiniteFloatIsolated(t *testing.T) {
+	tmpDir := t.TempDir()
+	snapshotPath := filepath.Join(tmpDir, "snapshot.json")
+	cfgFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("snapshot:\n  enable: true\n  path: "+snapshotPath), 0644))
+
+	mgr, err := NewSnapshotManager(cfgFile)
+	require.NoError(t, err)
+
+	mgr.Update("cpu", &MockInfo{Value: "cpu-data"})
+	mgr.Update("transceiver", &nonFiniteInfo{Power: math.Inf(-1)})
+
+	data, err := os.ReadFile(snapshotPath)
+	require.NoError(t, err)
+
+	var snapshot Snapshot
+	require.NoError(t, json.Unmarshal(data, &snapshot))
+
+	// Healthy component survives intact.
+	require.Contains(t, snapshot.Components, "cpu")
+	cpuMap := snapshot.Components["cpu"].(map[string]interface{})
+	assert.Equal(t, "cpu-data", cpuMap["value"])
+
+	// Offending component is present but reduced to an error placeholder.
+	require.Contains(t, snapshot.Components, "transceiver")
+	trMap := snapshot.Components["transceiver"].(map[string]interface{})
+	assert.Contains(t, trMap, "_snapshot_error")
+
+	// Node identity and uptime are preserved.
+	assert.NotEmpty(t, snapshot.Node)
+	assert.False(t, snapshot.BootTime.IsZero())
+	assert.Greater(t, snapshot.UptimeSeconds, float64(0))
 }
 
 func TestSnapshotManager_SetIssues(t *testing.T) {


### PR DESCRIPTION
两个提交:

### 1. feat(snapshot): capture node boot_time and uptime_seconds (1a1e199)
在 snapshot 顶层新增两个字段:
- `boot_time`(RFC3339,启动时算一次,稳定不变)
- `uptime_seconds`(每次 persist 刷新为当前值)

新增 `pkg/utils.GetUptime()` / `GetBootTime()`,读 `/proc/uptime`(不受 PID namespace 隔离,容器内直接读到宿主机值,无需 nsenter)。读取失败仅 warn、不阻断落盘。

### 2. fix(snapshot): stop a component's Inf/NaN float from freezing the whole snapshot (0ef9407)
**根因**:transceiver 暗光/未接 lane 的功率读数为 `"-inf dBm"`,`strconv.ParseFloat` 认 `"-inf"` 为合法值 → 存成 Go 的 `-Inf` → `persist()` 的 `json.MarshalIndent` 对 Inf/NaN 原子性报错 → 每个 tick 落盘全失败 → `snapshot.json` 静默冻结在最后一次成功写入。现场 shmaas-g90-007 冻结 10 天实证。

**两层修复**:
- 源头:`finiteOrZero()` 归零 transceiver 三处解析点(`parseDBM`/`parseMLXLinkBER`/`parseMLXLinkMultiLane`)的非有限值。
- 兜底:`persist()` 整体 marshal 失败时回退到逐组件 marshal,坏组件换 `_snapshot_error` 占位,其余(node/uptime/issues/健康组件)照常落盘。