### PR TITLE
feat(rdmaenv): passthrough rdma-env-pre exporter metrics into sichek

### DIFF
--- a/cmd/command/command.go
+++ b/cmd/command/command.go
@@ -83,6 +83,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(component.NewLldpCmd())
 	rootCmd.AddCommand(component.NewSysinfoCmd())
 	rootCmd.AddCommand(component.NewGpuProbeCmd())
+	rootCmd.AddCommand(component.NewRdmaEnvCmd())
 	rootCmd.AddCommand(NewConfigCmd())
 	return rootCmd
 }

--- a/cmd/command/component/all.go
+++ b/cmd/command/component/all.go
@@ -36,6 +36,7 @@ import (
 	"github.com/scitix/sichek/components/ovs"
 	"github.com/scitix/sichek/components/pcie/topotest"
 	"github.com/scitix/sichek/components/podlog"
+	"github.com/scitix/sichek/components/rdmaenv"
 	"github.com/scitix/sichek/components/sysinfo"
 	"github.com/scitix/sichek/components/syslog"
 	"github.com/scitix/sichek/components/transceiver"
@@ -208,6 +209,8 @@ func NewComponent(componentName string, cfgFile string, specFile string, ignored
 		return transceiver.NewComponent(cfgFile, specFile, ignoredCheckers)
 	case consts.ComponentNameOVS:
 		return ovs.NewComponent(cfgFile, specFile, ignoredCheckers)
+	case consts.ComponentNameRdmaEnv:
+		return rdmaenv.NewComponent(cfgFile, specFile)
 	case consts.ComponentNameLLDP:
 		return lldp.NewComponent(cfgFile, specFile)
 	case consts.ComponentNameSysinfo:

--- a/cmd/command/component/rdmaenv.go
+++ b/cmd/command/component/rdmaenv.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package component
+
+import (
+	"context"
+
+	"github.com/scitix/sichek/cmd/command/spec"
+	"github.com/scitix/sichek/components/rdmaenv"
+	"github.com/scitix/sichek/consts"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewRdmaEnvCmd() *cobra.Command {
+	var (
+		cfgFile string
+		verbose bool
+	)
+	rdmaEnvCmd := &cobra.Command{
+		Use:     "rdmaenv",
+		Aliases: []string{"rdma"},
+		Short:   "Passthrough rdma-env-pre exporter metrics into sichek",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx, cancel := context.WithTimeout(context.Background(), consts.CmdTimeout)
+			defer cancel()
+
+			if !verbose {
+				logrus.SetLevel(logrus.ErrorLevel)
+			} else {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+
+			resolvedCfgFile, err := spec.EnsureCfgFile(cfgFile)
+			if err != nil {
+				logrus.WithField("component", "rdmaenv").Errorf("failed to load cfgFile: %v", err)
+			} else {
+				logrus.WithField("component", "rdmaenv").Info("load cfgFile: " + resolvedCfgFile)
+			}
+
+			component, err := rdmaenv.NewComponent(resolvedCfgFile, "")
+			if err != nil {
+				logrus.WithField("component", "rdmaenv").Error(err)
+				return
+			}
+			result, err := RunComponentCheck(ctx, component, consts.CmdTimeout)
+			if err != nil {
+				return
+			}
+			PrintCheckResults(true, result)
+		},
+	}
+
+	rdmaEnvCmd.Flags().StringVarP(&cfgFile, "cfg", "c", "", "Path to the user config file")
+	rdmaEnvCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+
+	return rdmaEnvCmd
+}

--- a/components/rdmaenv/collector/collector.go
+++ b/components/rdmaenv/collector/collector.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultEndpoint = "http://127.0.0.1:19099/metrics"
+	defaultPrefix   = "rdma_env_pre_"
+	defaultTimeout  = 10 * time.Second
+)
+
+// Collector scrapes the rdma-env-pre exporter and turns its /metrics into an Info.
+type Collector struct {
+	endpoint string
+	timeout  time.Duration
+	prefix   string
+}
+
+// NewCollector builds a Collector, filling in defaults for empty/zero fields.
+func NewCollector(endpoint string, timeout time.Duration, prefix string) *Collector {
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+	if prefix == "" {
+		prefix = defaultPrefix
+	}
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	return &Collector{endpoint: endpoint, timeout: timeout, prefix: prefix}
+}
+
+// Collect scrapes once and returns an Info. A scrape failure is NOT surfaced as a Go
+// error: it is recorded in Info (Available=false, Error set) so the daemon does not
+// treat a missing/absent exporter as a component fault. The error return is always nil.
+func (c *Collector) Collect(ctx context.Context) (*Info, error) {
+	info := &Info{
+		Endpoint:  c.endpoint,
+		ScrapedAt: time.Now(),
+		Summary:   Summary{VerdictCounts: map[string]int{}},
+	}
+
+	body, err := scrape(ctx, c.endpoint, c.timeout)
+	if err != nil {
+		info.Available = false
+		info.Error = err.Error()
+		logrus.WithField("component", "rdmaenv").Warnf("scrape %s failed: %v", c.endpoint, err)
+		return info, nil
+	}
+
+	byName := ParseMetrics(body, c.prefix)
+	info.Available = true
+	info.Series = byName
+	info.Summary = BuildSummary(byName)
+	return info, nil
+}

--- a/components/rdmaenv/collector/collector_test.go
+++ b/components/rdmaenv/collector/collector_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectSuccess(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "metrics_sample.txt"))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewCollector(srv.URL, 5*time.Second, "rdma_env_pre_")
+	info, err := c.Collect(context.Background())
+	require.NoError(t, err)
+	assert.True(t, info.Available)
+	assert.Empty(t, info.Error)
+	assert.NotEmpty(t, info.Series)
+	assert.Equal(t, "drift", info.Summary.HostCompliance)
+	assert.Len(t, info.Summary.Knobs, 4)
+}
+
+func TestCollectConnRefusedDegrades(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // now nothing is listening
+
+	c := NewCollector(url, 1*time.Second, "rdma_env_pre_")
+	info, err := c.Collect(context.Background())
+	require.NoError(t, err) // failure must NOT be a component fault
+	assert.False(t, info.Available)
+	assert.NotEmpty(t, info.Error)
+	assert.Empty(t, info.Series)
+	assert.Equal(t, url, info.Endpoint)
+}
+
+func TestCollectNon2xxDegrades(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewCollector(srv.URL, 1*time.Second, "rdma_env_pre_")
+	info, err := c.Collect(context.Background())
+	require.NoError(t, err)
+	assert.False(t, info.Available)
+	assert.NotEmpty(t, info.Error)
+}

--- a/components/rdmaenv/collector/parse.go
+++ b/components/rdmaenv/collector/parse.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ParseMetrics parses a Prometheus text-exposition body into series grouped by metric
+// name, keeping only series whose name starts with prefix. It mirrors rdma-env-pre's
+// own renderer (a name{labels} value line, optional trailing timestamp); # HELP/# TYPE
+// and blank lines are skipped, and a malformed line is dropped rather than failing the
+// whole parse.
+func ParseMetrics(body, prefix string) map[string][]Series {
+	out := make(map[string][]Series)
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, labels, value, ok := parseLine(line)
+		if !ok {
+			continue
+		}
+		if prefix != "" && !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		out[name] = append(out[name], Series{Name: name, Labels: labels, Value: value})
+	}
+	return out
+}
+
+// parseLine parses one exposition line into name, labels, and value.
+func parseLine(line string) (name string, labels map[string]string, value float64, ok bool) {
+	labels = map[string]string{}
+	var rest string
+
+	i := strings.IndexAny(line, "{ ")
+	if i < 0 {
+		return "", nil, 0, false // no value present
+	}
+	if line[i] == '{' {
+		name = line[:i]
+		closeIdx := findLabelClose(line, i)
+		if closeIdx < 0 {
+			return "", nil, 0, false
+		}
+		labels = parseLabels(line[i+1 : closeIdx])
+		rest = strings.TrimSpace(line[closeIdx+1:])
+	} else {
+		name = line[:i]
+		rest = strings.TrimSpace(line[i+1:])
+	}
+
+	fields := strings.Fields(rest) // value [timestamp]; timestamp ignored
+	if len(fields) == 0 {
+		return "", nil, 0, false
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return "", nil, 0, false
+	}
+	if name == "" {
+		return "", nil, 0, false
+	}
+	return name, labels, v, true
+}
+
+// findLabelClose returns the index of the '}' that closes the label set opened at
+// open, skipping any '}' that appears inside a quoted label value.
+func findLabelClose(line string, open int) int {
+	inQuote := false
+	esc := false
+	for i := open + 1; i < len(line); i++ {
+		c := line[i]
+		if inQuote {
+			if esc {
+				esc = false
+				continue
+			}
+			switch c {
+			case '\\':
+				esc = true
+			case '"':
+				inQuote = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inQuote = true
+		case '}':
+			return i
+		}
+	}
+	return -1
+}
+
+// parseLabels parses a k="v",k2="v2" label body into a map, unescaping values.
+func parseLabels(s string) map[string]string {
+	m := map[string]string{}
+	for _, pair := range splitTopLevel(s) {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		rawKey, rawVal, found := strings.Cut(pair, "=")
+		if !found {
+			continue
+		}
+		k := strings.TrimSpace(rawKey)
+		v := strings.TrimSpace(rawVal)
+		v = strings.TrimPrefix(v, `"`)
+		v = strings.TrimSuffix(v, `"`)
+		if k == "" {
+			continue
+		}
+		m[k] = unescape(v)
+	}
+	return m
+}
+
+// splitTopLevel splits on commas that are not inside a quoted value.
+func splitTopLevel(s string) []string {
+	var parts []string
+	var cur strings.Builder
+	inQuote := false
+	esc := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inQuote {
+			cur.WriteByte(c)
+			if esc {
+				esc = false
+				continue
+			}
+			if c == '\\' {
+				esc = true
+			} else if c == '"' {
+				inQuote = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inQuote = true
+			cur.WriteByte(c)
+		case ',':
+			parts = append(parts, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	parts = append(parts, cur.String())
+	return parts
+}
+
+// unescape reverses Prometheus label-value escaping: \\ -> \, \" -> ", \n -> newline.
+func unescape(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '\\':
+				b.WriteByte('\\')
+				i++
+			case '"':
+				b.WriteByte('"')
+				i++
+			case 'n':
+				b.WriteByte('\n')
+				i++
+			default:
+				b.WriteByte(s[i])
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/components/rdmaenv/collector/parse_test.go
+++ b/components/rdmaenv/collector/parse_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMetricsSample(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "metrics_sample.txt"))
+	require.NoError(t, err)
+
+	byName := ParseMetrics(string(body), "rdma_env_pre_")
+
+	// non-prefixed series filtered out
+	assert.NotContains(t, byName, "other_exporter_metric")
+	// malformed line skipped
+	assert.NotContains(t, byName, "rdma_env_pre_broken_line")
+
+	// knob_verdict: 4 series, labels parsed
+	verdicts := byName["rdma_env_pre_knob_verdict"]
+	require.Len(t, verdicts, 4)
+	assert.Equal(t, "0000:19:00.0", verdicts[0].Labels["device"])
+	assert.Equal(t, "converged", verdicts[0].Labels["verdict"])
+	assert.Equal(t, "true", verdicts[3].Labels["reboot_required"])
+	assert.Equal(t, float64(1), verdicts[0].Value)
+
+	// numeric value families
+	obs := byName["rdma_env_pre_knob_observed_value"]
+	require.Len(t, obs, 3)
+	assert.Equal(t, float64(3), findByDevice(obs, "0000:ef:00.3").Value)
+
+	// info family (non-numeric values carried in labels)
+	info := byName["rdma_env_pre_knob_info"]
+	require.Len(t, info, 1)
+	assert.Equal(t, "dscp", info[0].Labels["desired"])
+	assert.Equal(t, "dscp", info[0].Labels["observed"])
+
+	// no-label series
+	up := byName["rdma_env_pre_agent_up"]
+	require.Len(t, up, 1)
+	assert.Empty(t, up[0].Labels)
+	assert.Equal(t, float64(1), up[0].Value)
+
+	// label with a value on a no-fabric family
+	build := byName["rdma_env_pre_build_info"]
+	require.Len(t, build, 1)
+	assert.Equal(t, "1.9.1-knobtest", build[0].Labels["version"])
+
+	// host_compliance state
+	hc := byName["rdma_env_pre_host_compliance"]
+	require.Len(t, hc, 1)
+	assert.Equal(t, "drift", hc[0].Labels["state"])
+}
+
+func TestParseMetricsEdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		wantOK     bool
+		wantName   string
+		wantValue  float64
+		wantLabels map[string]string
+	}{
+		{
+			name:       "no labels",
+			line:       "rdma_env_pre_agent_up 1",
+			wantOK:     true,
+			wantName:   "rdma_env_pre_agent_up",
+			wantValue:  1,
+			wantLabels: map[string]string{},
+		},
+		{
+			name:       "trailing timestamp ignored",
+			line:       `rdma_env_pre_x{a="b"} 5 1712345678`,
+			wantOK:     true,
+			wantName:   "rdma_env_pre_x",
+			wantValue:  5,
+			wantLabels: map[string]string{"a": "b"},
+		},
+		{
+			name:       "escaped quote and comma inside value",
+			line:       `rdma_env_pre_x{desc="a\"b,c",k="v"} 1`,
+			wantOK:     true,
+			wantName:   "rdma_env_pre_x",
+			wantValue:  1,
+			wantLabels: map[string]string{"desc": `a"b,c`, "k": "v"},
+		},
+		{
+			name:   "no value",
+			line:   `rdma_env_pre_x{a="b"}`,
+			wantOK: false,
+		},
+		{
+			name:   "bad value",
+			line:   `rdma_env_pre_x notanumber`,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, labels, value, ok := parseLine(tt.line)
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantValue, value)
+			assert.Equal(t, tt.wantLabels, labels)
+		})
+	}
+}
+
+func findByDevice(series []Series, device string) Series {
+	for _, s := range series {
+		if s.Labels["device"] == device {
+			return s
+		}
+	}
+	return Series{}
+}

--- a/components/rdmaenv/collector/rdmaenv_info.go
+++ b/components/rdmaenv/collector/rdmaenv_info.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"time"
+
+	"github.com/scitix/sichek/components/common"
+)
+
+// Series is one Prometheus sample, carried verbatim (name + labels + value) with no
+// interpretation of its meaning. It is what the metrics layer re-exports.
+type Series struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
+	Value  float64           `json:"value"`
+}
+
+// KnobView merges the same knob across the rdma_env_pre_knob_verdict /
+// _knob_desired_value / _knob_observed_value / _knob_info families into one row. It is
+// assembled by reading labels only -- no judgment.
+type KnobView struct {
+	Device         string `json:"device"`
+	Knob           string `json:"knob"`
+	Fabric         string `json:"fabric"`
+	Verdict        string `json:"verdict"`
+	Severity       string `json:"severity"`
+	Desired        string `json:"desired"`
+	Observed       string `json:"observed"`
+	RebootRequired bool   `json:"reboot_required"`
+}
+
+// ObserveView is a read-only inventory item: observed value only, no desired.
+type ObserveView struct {
+	Device   string `json:"device"`
+	Knob     string `json:"knob"`
+	Observed string `json:"observed"`
+}
+
+// Summary is the human-readable digest that lands in the snapshot.
+type Summary struct {
+	HostCompliance string         `json:"host_compliance"`
+	VerdictCounts  map[string]int `json:"verdict_counts"`
+	SeriesTotal    int            `json:"series_total"`
+	Knobs          []KnobView     `json:"knobs"`
+	Observes       []ObserveView  `json:"observes,omitempty"`
+}
+
+// Info is the collector output. Series is kept in memory for the metrics layer only
+// (json:"-"), so the snapshot carries just Summary + meta.
+type Info struct {
+	Available bool                `json:"available"`
+	Endpoint  string              `json:"endpoint"`
+	ScrapedAt time.Time           `json:"scraped_at"`
+	Error     string              `json:"error,omitempty"`
+	Series    map[string][]Series `json:"-"`
+	Summary   Summary             `json:"summary"`
+}
+
+// JSON implements common.Info.
+func (i *Info) JSON() (string, error) {
+	data, err := common.JSON(i)
+	return string(data), err
+}

--- a/components/rdmaenv/collector/scrape.go
+++ b/components/rdmaenv/collector/scrape.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// scrape does a single GET of the exporter's /metrics and returns the body. The
+// rdma-env-pre exporter has no authentication, so this is a plain request bounded by
+// timeout. A non-2xx status is an error.
+func scrape(ctx context.Context, endpoint string, timeout time.Duration) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(cctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, endpoint)
+	}
+	return string(body), nil
+}

--- a/components/rdmaenv/collector/summary.go
+++ b/components/rdmaenv/collector/summary.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"sort"
+	"strconv"
+)
+
+// Upstream (rdma-env-pre) metric names this summary reads. Frozen by the exporter's
+// contract.go; passthrough itself does not depend on this list (parse keeps everything
+// with the prefix) -- these are only for building the human-readable digest.
+const (
+	metricKnobVerdict  = "rdma_env_pre_knob_verdict"
+	metricHostComplian = "rdma_env_pre_host_compliance"
+	metricHostCount    = "rdma_env_pre_host_knob_count"
+	metricObserve      = "rdma_env_pre_observe"
+	metricDesiredValue = "rdma_env_pre_knob_desired_value"
+	metricObservedVal  = "rdma_env_pre_knob_observed_value"
+	metricKnobInfo     = "rdma_env_pre_knob_info"
+)
+
+// BuildSummary folds the scraped series into the snapshot digest: one row per knob with
+// its desired/observed value, plus host compliance, per-verdict counts, and observes.
+// It reads labels only -- no judgment, no invented values.
+func BuildSummary(byName map[string][]Series) Summary {
+	s := Summary{VerdictCounts: map[string]int{}}
+
+	// SeriesTotal counts everything passed through, not just the families read here.
+	for _, series := range byName {
+		s.SeriesTotal += len(series)
+	}
+
+	// Host compliance state.
+	if hc := byName[metricHostComplian]; len(hc) > 0 {
+		s.HostCompliance = hc[0].Labels["state"]
+	}
+
+	// Per-verdict counts.
+	for _, series := range byName[metricHostCount] {
+		if v := series.Labels["verdict"]; v != "" {
+			s.VerdictCounts[v] = int(series.Value)
+		}
+	}
+
+	// Value indexes keyed by (device,knob,fabric).
+	numDesired := indexByKnob(byName[metricDesiredValue])
+	numObserved := indexByKnob(byName[metricObservedVal])
+	infoDesired, infoObserved := indexInfo(byName[metricKnobInfo])
+
+	for _, series := range byName[metricKnobVerdict] {
+		l := series.Labels
+		key := l["device"] + "\x00" + l["knob"] + "\x00" + l["fabric"]
+		kv := KnobView{
+			Device:         l["device"],
+			Knob:           l["knob"],
+			Fabric:         l["fabric"],
+			Verdict:        l["verdict"],
+			Severity:       l["severity"],
+			RebootRequired: l["reboot_required"] == "true",
+		}
+		// Numeric knob takes the value families; otherwise the info family.
+		if d, ok := numDesired[key]; ok {
+			kv.Desired = d
+		} else if d, ok := infoDesired[key]; ok {
+			kv.Desired = d
+		}
+		if o, ok := numObserved[key]; ok {
+			kv.Observed = o
+		} else if o, ok := infoObserved[key]; ok {
+			kv.Observed = o
+		}
+		s.Knobs = append(s.Knobs, kv)
+	}
+
+	// Observe-only inventory (observed value, no desired).
+	for _, series := range byName[metricObserve] {
+		s.Observes = append(s.Observes, ObserveView{
+			Device:   series.Labels["device"],
+			Knob:     series.Labels["knob"],
+			Observed: formatValue(series.Value),
+		})
+	}
+
+	sort.Slice(s.Knobs, func(i, j int) bool {
+		if s.Knobs[i].Device != s.Knobs[j].Device {
+			return s.Knobs[i].Device < s.Knobs[j].Device
+		}
+		return s.Knobs[i].Knob < s.Knobs[j].Knob
+	})
+	sort.Slice(s.Observes, func(i, j int) bool {
+		if s.Observes[i].Device != s.Observes[j].Device {
+			return s.Observes[i].Device < s.Observes[j].Device
+		}
+		return s.Observes[i].Knob < s.Observes[j].Knob
+	})
+
+	return s
+}
+
+// indexByKnob maps (device,knob,fabric) -> formatted numeric value.
+func indexByKnob(series []Series) map[string]string {
+	m := make(map[string]string, len(series))
+	for _, s := range series {
+		key := s.Labels["device"] + "\x00" + s.Labels["knob"] + "\x00" + s.Labels["fabric"]
+		m[key] = formatValue(s.Value)
+	}
+	return m
+}
+
+// indexInfo maps (device,knob,fabric) -> desired/observed string from knob_info labels.
+func indexInfo(series []Series) (desired, observed map[string]string) {
+	desired = make(map[string]string, len(series))
+	observed = make(map[string]string, len(series))
+	for _, s := range series {
+		key := s.Labels["device"] + "\x00" + s.Labels["knob"] + "\x00" + s.Labels["fabric"]
+		desired[key] = s.Labels["desired"]
+		observed[key] = s.Labels["observed"]
+	}
+	return desired, observed
+}
+
+// formatValue renders a float as the shortest decimal that round-trips.
+func formatValue(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}

--- a/components/rdmaenv/collector/summary_test.go
+++ b/components/rdmaenv/collector/summary_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSummaryFromSample(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "metrics_sample.txt"))
+	require.NoError(t, err)
+	sum := BuildSummary(ParseMetrics(string(body), "rdma_env_pre_"))
+
+	assert.Equal(t, "drift", sum.HostCompliance)
+	assert.Equal(t, map[string]int{"converged": 2, "drift": 1, "pending_reboot": 1}, sum.VerdictCounts)
+
+	// 4 knob_verdict rows, sorted by (device, knob).
+	require.Len(t, sum.Knobs, 4)
+
+	// Numeric knob: desired/observed come from the value families.
+	ipgDrift := findKnob(sum.Knobs, "0000:ef:00.3", "qos.ipg")
+	require.NotNil(t, ipgDrift)
+	assert.Equal(t, "drift", ipgDrift.Verdict)
+	assert.Equal(t, "25", ipgDrift.Desired)
+	assert.Equal(t, "3", ipgDrift.Observed)
+
+	// pending_reboot knob carries reboot_required=true.
+	vfs := findKnob(sum.Knobs, "0000:19:00.0", "firmware.NUM_OF_VFS")
+	require.NotNil(t, vfs)
+	assert.Equal(t, "pending_reboot", vfs.Verdict)
+	assert.True(t, vfs.RebootRequired)
+	assert.Equal(t, "16", vfs.Desired)
+	assert.Equal(t, "8", vfs.Observed)
+
+	// Non-numeric knob: desired/observed come from knob_info labels.
+	trust := findKnob(sum.Knobs, "eth_r0_p0", "qos.trust")
+	require.NotNil(t, trust)
+	assert.Equal(t, "dscp", trust.Desired)
+	assert.Equal(t, "dscp", trust.Observed)
+
+	// Observe-only inventory.
+	require.Len(t, sum.Observes, 1)
+	assert.Equal(t, "pcie.link_width", sum.Observes[0].Knob)
+	assert.Equal(t, "16", sum.Observes[0].Observed)
+
+	// SeriesTotal counts every passed-through series (incl. agent_up, build_info).
+	assert.Equal(t, 18, sum.SeriesTotal)
+}
+
+func TestBuildSummaryEmpty(t *testing.T) {
+	sum := BuildSummary(map[string][]Series{})
+	assert.Equal(t, "", sum.HostCompliance)
+	assert.Empty(t, sum.Knobs)
+	assert.Equal(t, 0, sum.SeriesTotal)
+	assert.NotNil(t, sum.VerdictCounts)
+}
+
+func findKnob(knobs []KnobView, device, knob string) *KnobView {
+	for i := range knobs {
+		if knobs[i].Device == device && knobs[i].Knob == knob {
+			return &knobs[i]
+		}
+	}
+	return nil
+}

--- a/components/rdmaenv/collector/testdata/metrics_sample.txt
+++ b/components/rdmaenv/collector/testdata/metrics_sample.txt
@@ -1,0 +1,40 @@
+# HELP rdma_env_pre_knob_verdict config knob consistency verdict
+# TYPE rdma_env_pre_knob_verdict gauge
+rdma_env_pre_knob_verdict{host="gpu-node-07",device="0000:19:00.0",knob="qos.ipg",fabric="compute",verdict="converged",severity="major",reboot_required="false"} 1
+rdma_env_pre_knob_verdict{host="gpu-node-07",device="0000:ef:00.3",knob="qos.ipg",fabric="compute",verdict="drift",severity="major",reboot_required="false"} 1
+rdma_env_pre_knob_verdict{host="gpu-node-07",device="eth_r0_p0",knob="qos.trust",fabric="compute",verdict="converged",severity="critical",reboot_required="false"} 1
+rdma_env_pre_knob_verdict{host="gpu-node-07",device="0000:19:00.0",knob="firmware.NUM_OF_VFS",fabric="storage",verdict="pending_reboot",severity="minor",reboot_required="true"} 1
+# HELP rdma_env_pre_host_compliance host compliance state
+# TYPE rdma_env_pre_host_compliance gauge
+rdma_env_pre_host_compliance{host="gpu-node-07",state="drift"} 1
+# HELP rdma_env_pre_host_knob_count count of knobs per verdict
+# TYPE rdma_env_pre_host_knob_count gauge
+rdma_env_pre_host_knob_count{host="gpu-node-07",verdict="converged"} 2
+rdma_env_pre_host_knob_count{host="gpu-node-07",verdict="drift"} 1
+rdma_env_pre_host_knob_count{host="gpu-node-07",verdict="pending_reboot"} 1
+# HELP rdma_env_pre_observe observe-only knob inventory
+# TYPE rdma_env_pre_observe gauge
+rdma_env_pre_observe{host="gpu-node-07",device="0000:19:00.0",knob="pcie.link_width"} 16
+# HELP rdma_env_pre_knob_desired_value desired value of a numeric config knob
+# TYPE rdma_env_pre_knob_desired_value gauge
+rdma_env_pre_knob_desired_value{host="gpu-node-07",device="0000:19:00.0",knob="qos.ipg",fabric="compute"} 25
+rdma_env_pre_knob_desired_value{host="gpu-node-07",device="0000:ef:00.3",knob="qos.ipg",fabric="compute"} 25
+rdma_env_pre_knob_desired_value{host="gpu-node-07",device="0000:19:00.0",knob="firmware.NUM_OF_VFS",fabric="storage"} 16
+# HELP rdma_env_pre_knob_observed_value observed value of a numeric config knob
+# TYPE rdma_env_pre_knob_observed_value gauge
+rdma_env_pre_knob_observed_value{host="gpu-node-07",device="0000:19:00.0",knob="qos.ipg",fabric="compute"} 25
+rdma_env_pre_knob_observed_value{host="gpu-node-07",device="0000:ef:00.3",knob="qos.ipg",fabric="compute"} 3
+rdma_env_pre_knob_observed_value{host="gpu-node-07",device="0000:19:00.0",knob="firmware.NUM_OF_VFS",fabric="storage"} 8
+# HELP rdma_env_pre_knob_info desired/observed value of a non-numeric config knob
+# TYPE rdma_env_pre_knob_info gauge
+rdma_env_pre_knob_info{host="gpu-node-07",device="eth_r0_p0",knob="qos.trust",fabric="compute",desired="dscp",observed="dscp"} 1
+# HELP rdma_env_pre_agent_up 1 while the exporter is serving.
+# TYPE rdma_env_pre_agent_up gauge
+rdma_env_pre_agent_up 1
+# HELP rdma_env_pre_build_info The running rdma-env-pre version (value always 1).
+# TYPE rdma_env_pre_build_info gauge
+rdma_env_pre_build_info{version="1.9.1-knobtest"} 1
+# a non-prefixed series that must be filtered out
+other_exporter_metric{foo="bar"} 42
+# a malformed line that must be skipped
+rdma_env_pre_broken_line{host="x" not_a_value

--- a/components/rdmaenv/config/config.go
+++ b/components/rdmaenv/config/config.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/scitix/sichek/components/common"
+
+// RdmaEnvUserConfig is the top-level user config for the rdmaenv component.
+type RdmaEnvUserConfig struct {
+	RdmaEnv *RdmaEnvConfig `json:"rdmaenv" yaml:"rdmaenv"`
+}
+
+// RdmaEnvConfig holds the runtime tunables for scraping the rdma-env-pre exporter.
+// There are no credentials: the exporter's /metrics endpoint has no auth.
+type RdmaEnvConfig struct {
+	QueryInterval common.Duration `json:"query_interval" yaml:"query_interval"`
+	// Endpoint is the rdma-env-pre exporter URL, e.g. http://127.0.0.1:19099/metrics.
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	// Timeout bounds a single scrape.
+	Timeout common.Duration `json:"timeout" yaml:"timeout"`
+	// MetricPrefix is the allow-list prefix: only series whose name starts with it are
+	// passed through (guards against an endpoint that mixes in unrelated metrics).
+	MetricPrefix string `json:"metric_prefix" yaml:"metric_prefix"`
+	// EnableMetrics toggles re-exporting the scraped series on sichek's own /metrics.
+	EnableMetrics bool `json:"enable_metrics" yaml:"enable_metrics"`
+}
+
+func (c *RdmaEnvUserConfig) GetQueryInterval() common.Duration {
+	if c.RdmaEnv == nil {
+		return common.Duration{}
+	}
+	return c.RdmaEnv.QueryInterval
+}
+
+func (c *RdmaEnvUserConfig) SetQueryInterval(newInterval common.Duration) {
+	if c.RdmaEnv == nil {
+		c.RdmaEnv = &RdmaEnvConfig{}
+	}
+	c.RdmaEnv.QueryInterval = newInterval
+}

--- a/components/rdmaenv/config/default_rdmaenv_user_config.yaml
+++ b/components/rdmaenv/config/default_rdmaenv_user_config.yaml
@@ -1,0 +1,6 @@
+rdmaenv:
+  query_interval: 10m
+  endpoint: "http://127.0.0.1:19099/metrics"
+  timeout: 10s
+  metric_prefix: "rdma_env_pre_"
+  enable_metrics: true

--- a/components/rdmaenv/metrics/metrics.go
+++ b/components/rdmaenv/metrics/metrics.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics re-exports the scraped rdma-env-pre series verbatim on sichek's own
+// Prometheus registry. It deliberately does NOT use sichek's GaugeVecMetricExporter:
+// that helper force-appends a "node" label, prefixes+sanitizes the metric name, and
+// fixes one label-key set per exporter -- all of which would break byte-for-byte
+// passthrough. Here each upstream metric name gets its own GaugeVec with its own label
+// keys, the name is kept exactly, and no extra label is added.
+package metrics
+
+import (
+	"errors"
+	"sort"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scitix/sichek/components/rdmaenv/collector"
+	"github.com/sirupsen/logrus"
+)
+
+type RdmaEnvMetrics struct {
+	reg    prometheus.Registerer
+	mu     sync.Mutex
+	gauges map[string]*prometheus.GaugeVec
+	keys   map[string][]string // metric name -> sorted label keys (fixed on first sight)
+}
+
+// NewRdmaEnvMetrics uses the global default registry, which sichek's promhttp serves.
+func NewRdmaEnvMetrics() *RdmaEnvMetrics {
+	return newRdmaEnvMetricsWith(prometheus.DefaultRegisterer)
+}
+
+func newRdmaEnvMetricsWith(reg prometheus.Registerer) *RdmaEnvMetrics {
+	return &RdmaEnvMetrics{
+		reg:    reg,
+		gauges: make(map[string]*prometheus.GaugeVec),
+		keys:   make(map[string][]string),
+	}
+}
+
+// ExportMetrics rebuilds the whole passthrough set from the current scrape: it resets
+// every known GaugeVec first (so a series that vanished upstream does not linger), then
+// re-sets the current series. On an unavailable scrape it resets and exports nothing.
+func (m *RdmaEnvMetrics) ExportMetrics(info *collector.Info) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, g := range m.gauges {
+		g.Reset()
+	}
+	if info == nil || !info.Available {
+		return
+	}
+
+	for name, series := range info.Series {
+		for i := range series {
+			s := &series[i]
+			gauge, keys := m.gaugeFor(name, s.Labels)
+			if gauge == nil {
+				continue
+			}
+			vals := make([]string, len(keys))
+			for j, k := range keys {
+				vals[j] = s.Labels[k]
+			}
+			gauge.WithLabelValues(vals...).Set(s.Value)
+		}
+	}
+}
+
+// gaugeFor returns the GaugeVec for a metric name, registering it on first sight with a
+// fixed (sorted) label-key set. A later series whose key set differs is rejected to
+// avoid a WithLabelValues panic.
+func (m *RdmaEnvMetrics) gaugeFor(name string, labels map[string]string) (*prometheus.GaugeVec, []string) {
+	if g, ok := m.gauges[name]; ok {
+		if !sameKeys(m.keys[name], labels) {
+			logrus.WithField("component", "rdmaenv").Warnf("metric %s label-key set changed, skipping series", name)
+			return nil, nil
+		}
+		return g, m.keys[name]
+	}
+
+	keys := sortedKeys(labels)
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name}, keys)
+	if err := m.reg.Register(g); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(*prometheus.GaugeVec); ok {
+				m.gauges[name] = existing
+				m.keys[name] = keys
+				return existing, keys
+			}
+		}
+		logrus.WithField("component", "rdmaenv").Warnf("register metric %s failed: %v", name, err)
+		return nil, nil
+	}
+	m.gauges[name] = g
+	m.keys[name] = keys
+	return g, keys
+}
+
+func sortedKeys(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sameKeys reports whether labels has exactly the key set want.
+func sameKeys(want []string, labels map[string]string) bool {
+	if len(want) != len(labels) {
+		return false
+	}
+	for _, k := range want {
+		if _, ok := labels[k]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/components/rdmaenv/metrics/metrics_test.go
+++ b/components/rdmaenv/metrics/metrics_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scitix/sichek/components/rdmaenv/collector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleValue(t *testing.T, reg *prometheus.Registry, name string, wantLabels map[string]string) (float64, bool) {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labelsEqual(labels, wantLabels) {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func sampleCount(t *testing.T, reg *prometheus.Registry, name string) int {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return len(mf.GetMetric())
+		}
+	}
+	return 0
+}
+
+func labelsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestExportMetricsPassthrough(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRdmaEnvMetricsWith(reg)
+
+	info := &collector.Info{
+		Available: true,
+		Series: map[string][]collector.Series{
+			"rdma_env_pre_knob_verdict": {
+				{Name: "rdma_env_pre_knob_verdict", Labels: map[string]string{"device": "d0", "knob": "k0", "verdict": "drift"}, Value: 1},
+				{Name: "rdma_env_pre_knob_verdict", Labels: map[string]string{"device": "d1", "knob": "k1", "verdict": "converged"}, Value: 1},
+			},
+			"rdma_env_pre_knob_observed_value": {
+				{Name: "rdma_env_pre_knob_observed_value", Labels: map[string]string{"device": "d0", "knob": "k0"}, Value: 3},
+			},
+			"rdma_env_pre_agent_up": {
+				{Name: "rdma_env_pre_agent_up", Labels: map[string]string{}, Value: 1},
+			},
+		},
+	}
+	m.ExportMetrics(info)
+
+	// Values preserved verbatim, no node label added.
+	v, ok := sampleValue(t, reg, "rdma_env_pre_knob_observed_value", map[string]string{"device": "d0", "knob": "k0"})
+	require.True(t, ok)
+	assert.Equal(t, float64(3), v)
+	assert.Equal(t, 2, sampleCount(t, reg, "rdma_env_pre_knob_verdict"))
+	assert.Equal(t, 1, sampleCount(t, reg, "rdma_env_pre_agent_up"))
+}
+
+func TestExportMetricsResetsStaleSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRdmaEnvMetricsWith(reg)
+
+	m.ExportMetrics(&collector.Info{
+		Available: true,
+		Series: map[string][]collector.Series{
+			"rdma_env_pre_knob_verdict": {
+				{Name: "rdma_env_pre_knob_verdict", Labels: map[string]string{"device": "d0", "knob": "k0", "verdict": "drift"}, Value: 1},
+				{Name: "rdma_env_pre_knob_verdict", Labels: map[string]string{"device": "d1", "knob": "k1", "verdict": "converged"}, Value: 1},
+			},
+			"rdma_env_pre_agent_up": {
+				{Name: "rdma_env_pre_agent_up", Labels: map[string]string{}, Value: 1},
+			},
+		},
+	})
+	require.Equal(t, 2, sampleCount(t, reg, "rdma_env_pre_knob_verdict"))
+
+	// Second scrape: one knob converged (dropped), agent_up gone entirely.
+	m.ExportMetrics(&collector.Info{
+		Available: true,
+		Series: map[string][]collector.Series{
+			"rdma_env_pre_knob_verdict": {
+				{Name: "rdma_env_pre_knob_verdict", Labels: map[string]string{"device": "d0", "knob": "k0", "verdict": "drift"}, Value: 1},
+			},
+		},
+	})
+	assert.Equal(t, 1, sampleCount(t, reg, "rdma_env_pre_knob_verdict"))
+	assert.Equal(t, 0, sampleCount(t, reg, "rdma_env_pre_agent_up"))
+}
+
+func TestExportMetricsUnavailableClears(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRdmaEnvMetricsWith(reg)
+
+	m.ExportMetrics(&collector.Info{
+		Available: true,
+		Series: map[string][]collector.Series{
+			"rdma_env_pre_agent_up": {
+				{Name: "rdma_env_pre_agent_up", Labels: map[string]string{}, Value: 1},
+			},
+		},
+	})
+	require.Equal(t, 1, sampleCount(t, reg, "rdma_env_pre_agent_up"))
+
+	m.ExportMetrics(&collector.Info{Available: false})
+	assert.Equal(t, 0, sampleCount(t, reg, "rdma_env_pre_agent_up"))
+}

--- a/components/rdmaenv/rdmaenv.go
+++ b/components/rdmaenv/rdmaenv.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rdmaenv is a passthrough component: it scrapes the co-located rdma-env-pre
+// exporter (:19099/metrics), re-exports its series verbatim on sichek's /metrics, and
+// records a per-knob desired/observed digest in the snapshot. It does no health
+// judgment: HealthCheck runs no checkers and always reports normal.
+package rdmaenv
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/scitix/sichek/components/common"
+	"github.com/scitix/sichek/components/rdmaenv/collector"
+	"github.com/scitix/sichek/components/rdmaenv/config"
+	rmetrics "github.com/scitix/sichek/components/rdmaenv/metrics"
+	"github.com/scitix/sichek/consts"
+	"github.com/scitix/sichek/pkg/utils"
+
+	"github.com/sirupsen/logrus"
+)
+
+type component struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	componentName string
+	cfg           *config.RdmaEnvUserConfig
+	cfgMutex      sync.Mutex
+	collector     *collector.Collector
+	metrics       *rmetrics.RdmaEnvMetrics
+
+	cacheMtx    sync.RWMutex
+	cacheBuffer []*common.Result
+	cacheInfo   []common.Info
+	currIndex   int64
+	cacheSize   int64
+
+	service *common.CommonService
+}
+
+var (
+	rdmaEnvComponent     *component
+	rdmaEnvComponentOnce sync.Once
+)
+
+// NewComponent builds (once) the rdmaenv component. specFile is accepted for factory
+// signature symmetry but unused: this component has no hardware spec baseline.
+func NewComponent(cfgFile string, specFile string) (common.Component, error) {
+	var err error
+	rdmaEnvComponentOnce.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic occurred when create component rdmaenv: %v", r)
+			}
+		}()
+		rdmaEnvComponent, err = newComponent(cfgFile)
+	})
+	return rdmaEnvComponent, err
+}
+
+func newComponent(cfgFile string) (comp *component, err error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
+	cfg := &config.RdmaEnvUserConfig{}
+	if e := common.LoadUserConfig(cfgFile, cfg); e != nil || cfg.RdmaEnv == nil {
+		logrus.WithField("component", "rdmaenv").Warnf("get user config failed or rdmaenv config is nil, using default config")
+		cfg.RdmaEnv = &config.RdmaEnvConfig{
+			QueryInterval: common.Duration{Duration: 10 * time.Minute},
+			Endpoint:      "http://127.0.0.1:19099/metrics",
+			Timeout:       common.Duration{Duration: 10 * time.Second},
+			MetricPrefix:  "rdma_env_pre_",
+			EnableMetrics: true,
+		}
+	}
+
+	collectorInst := collector.NewCollector(cfg.RdmaEnv.Endpoint, cfg.RdmaEnv.Timeout.Duration, cfg.RdmaEnv.MetricPrefix)
+
+	const cacheSize = 5
+	comp = &component{
+		ctx:           ctx,
+		cancel:        cancel,
+		componentName: consts.ComponentNameRdmaEnv,
+		cfg:           cfg,
+		collector:     collectorInst,
+		metrics:       rmetrics.NewRdmaEnvMetrics(),
+		cacheBuffer:   make([]*common.Result, cacheSize),
+		cacheInfo:     make([]common.Info, cacheSize),
+		cacheSize:     cacheSize,
+	}
+	comp.service = common.NewCommonService(ctx, cfg, comp.componentName, comp.GetTimeout(), comp.HealthCheck)
+	return comp, nil
+}
+
+func (c *component) Name() string {
+	return c.componentName
+}
+
+func (c *component) HealthCheck(ctx context.Context) (*common.Result, error) {
+	info, err := c.collector.Collect(ctx)
+	if err != nil {
+		logrus.WithField("component", "rdmaenv").Errorf("failed to collect rdmaenv info: %v", err)
+		return nil, err
+	}
+	if c.cfg.RdmaEnv != nil && c.cfg.RdmaEnv.EnableMetrics {
+		c.metrics.ExportMetrics(info)
+	}
+
+	// No checkers: passthrough never judges. Check with a nil checker set yields a
+	// normal, info-level result.
+	result := common.Check(ctx, c.componentName, info, nil)
+
+	c.cacheMtx.Lock()
+	c.cacheBuffer[c.currIndex] = result
+	c.cacheInfo[c.currIndex] = info
+	c.currIndex = (c.currIndex + 1) % c.cacheSize
+	c.cacheMtx.Unlock()
+
+	if info.Available {
+		logrus.WithField("component", "rdmaenv").Infof("rdma-env-pre scrape OK: %d series, host=%s", info.Summary.SeriesTotal, info.Summary.HostCompliance)
+	} else {
+		logrus.WithField("component", "rdmaenv").Warnf("rdma-env-pre unavailable at %s: %s", info.Endpoint, info.Error)
+	}
+	return result, nil
+}
+
+func (c *component) CacheResults() ([]*common.Result, error) {
+	c.cacheMtx.RLock()
+	defer c.cacheMtx.RUnlock()
+	return c.cacheBuffer, nil
+}
+
+func (c *component) LastResult() (*common.Result, error) {
+	c.cacheMtx.RLock()
+	defer c.cacheMtx.RUnlock()
+	result := c.cacheBuffer[c.currIndex]
+	if c.currIndex == 0 {
+		result = c.cacheBuffer[c.cacheSize-1]
+	}
+	return result, nil
+}
+
+func (c *component) CacheInfos() ([]common.Info, error) {
+	c.cacheMtx.RLock()
+	defer c.cacheMtx.RUnlock()
+	return c.cacheInfo, nil
+}
+
+func (c *component) LastInfo() (common.Info, error) {
+	c.cacheMtx.RLock()
+	defer c.cacheMtx.RUnlock()
+	if c.currIndex == 0 {
+		return c.cacheInfo[c.cacheSize-1], nil
+	}
+	return c.cacheInfo[c.currIndex-1], nil
+}
+
+func (c *component) Start() <-chan *common.Result {
+	return c.service.Start()
+}
+
+func (c *component) Stop() error {
+	return c.service.Stop()
+}
+
+func (c *component) Update(cfg common.ComponentUserConfig) error {
+	c.cfgMutex.Lock()
+	configPointer, ok := cfg.(*config.RdmaEnvUserConfig)
+	if !ok {
+		c.cfgMutex.Unlock()
+		return fmt.Errorf("update wrong config type for rdmaenv")
+	}
+	c.cfg = configPointer
+	c.cfgMutex.Unlock()
+	return c.service.Update(cfg)
+}
+
+func (c *component) Status() bool {
+	return c.service.Status()
+}
+
+func (c *component) GetTimeout() time.Duration {
+	return c.cfg.GetQueryInterval().Duration
+}
+
+// PrintInfo prints the passthrough digest. It always returns true: passthrough does not
+// participate in pass/fail.
+func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPrint bool) bool {
+	utils.PrintTitle("RdmaEnv", "-")
+
+	rInfo, ok := info.(*collector.Info)
+	if !ok || rInfo == nil {
+		fmt.Println("No rdmaenv info available")
+		return true
+	}
+
+	fmt.Printf("Endpoint: %s\n", rInfo.Endpoint)
+	if !rInfo.Available {
+		fmt.Printf("Available: false  (%s)\n", rInfo.Error)
+		return true
+	}
+
+	fmt.Printf("Available: true   Series: %d   HostCompliance: %s\n",
+		rInfo.Summary.SeriesTotal, rInfo.Summary.HostCompliance)
+	if len(rInfo.Summary.VerdictCounts) > 0 {
+		fmt.Printf("VerdictCounts: %v\n", rInfo.Summary.VerdictCounts)
+	}
+
+	printed := false
+	for _, k := range rInfo.Summary.Knobs {
+		if k.Verdict == "converged" {
+			continue
+		}
+		if !printed {
+			fmt.Printf("\nNon-converged knobs:\n")
+			fmt.Printf("%-18s %-26s %-10s %-14s %-14s\n", "Device", "Knob", "Verdict", "Desired", "Observed")
+			printed = true
+		}
+		fmt.Printf("%-18s %-26s %-10s %-14s %-14s\n", k.Device, k.Knob, k.Verdict, k.Desired, k.Observed)
+	}
+	if !printed {
+		fmt.Printf("\nAll knobs converged\n")
+	}
+	fmt.Println()
+	return true
+}

--- a/config/default_user_config.yaml
+++ b/config/default_user_config.yaml
@@ -116,3 +116,13 @@ gpuprobe:
   query_interval: 600s
   cache_size: 5
   enable_metrics: true
+
+# rdmaenv is default-off (not in consts.DefaultComponents); this section only
+# lets it load when explicitly enabled via `-E rdmaenv` or `sichek rdmaenv`.
+# It scrapes the co-located rdma-env-pre exporter and passes its metrics through.
+rdmaenv:
+  query_interval: 10m
+  endpoint: "http://127.0.0.1:19099/metrics"
+  timeout: 10s
+  metric_prefix: "rdma_env_pre_"
+  enable_metrics: true

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -51,6 +51,7 @@ const (
 	ComponentNameOVS          = "ovs"
 	ComponentNameSysinfo      = "sysinfo"
 	ComponentNameGPUProbe     = "gpuprobe"
+	ComponentNameRdmaEnv      = "rdmaenv"
 
 	/*----------------------checker id------------------------*/
 	CheckerIDInfinibandFW            = "4001"


### PR DESCRIPTION
## 概述

新增 sichek 组件 `rdmaenv`,把同机 rdma-env-pre exporter(`:19099/metrics`,无 auth)的指标
**原名透传**进 sichek 自己的 `/metrics`,并把逐 knob 的期望/实测值(desired/observed)落进 snapshot。
**纯透传**:不做健康判定,不产 CheckerResult,不写 K8s annotation,不改指标名。

- 采集:每个 tick 拉一次 `:19099` → 通用 Prometheus text parser → `Info`(全量 series + 摘要)
- /metrics:自管 `map[name]*GaugeVec` 原名重导出(保留 `rdma_env_pre_*`,**不加 node label**,每 tick Reset 重灌,跟随上游"全量重生无 stale")
- snapshot:`components.rdmaenv.summary` 逐 knob 的 verdict/desired/observed,全量覆盖
- **默认关**,`-E rdmaenv` 启用;拉不到时优雅降级(`available=false`,不当组件故障,`/metrics` 无残留)

不复用 `metrics.GaugeVecMetricExporter`(它会强制加 node label + 拼 prefix + 固定 label 集,破坏原样透传)。

## 改动

- 新增 `components/rdmaenv/`(config / collector{scrape,parse,summary} / metrics / rdmaenv.go)
- 新增 CLI 子命令 `cmd/command/component/rdmaenv.go`(`rdmaenv`,别名 `rdma`)
- wiring:`consts.go`(加 `ComponentNameRdmaEnv`)、`all.go`(工厂 case)、`command.go`(命令注册)
- 单测覆盖 parser / summary 合成 / scrape+降级 / metrics Reset 语义