### PR TITLE
feat(components): config-driven opt-in for default-off components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ specs_download/
 /local
 *.md
 .claude
+*.html

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,6 +82,12 @@ nfpms:
       preremove: ./scripts/preuninstall.sh
 
     contents:
+      # systemd unit shipped on disk so `systemctl enable/start/status
+      # sichek.service` works right after install (postinstall runs
+      # `systemctl daemon-reload`). The service is NOT auto-enabled or started
+      # by the package — that stays an explicit operator choice.
+      - src: ./systemd/sichek.service
+        dst: /etc/systemd/system/sichek.service
       - src: ./components/cpu/config/*.yaml
         dst: /var/sichek/config/cpu/
       - src: ./components/dmesg/config/*.yaml

--- a/cmd/command/component/all.go
+++ b/cmd/command/component/all.go
@@ -93,18 +93,20 @@ func NewAllCmd() *cobra.Command {
 			}
 
 			componentsToCheck := DetermineComponentsToCheck(enableComponents, ignoreComponents, resolvedCfgFile, "all")
+			enabledOptIn := EnabledOptInComponents(resolvedCfgFile)
 			checkResults := make([]*CheckResults, len(componentsToCheck))
 			var wg sync.WaitGroup
 			for idx, componentName := range componentsToCheck {
 				if componentName == consts.ComponentNameInfiniband && !utils.IsInfinibandExist() {
 					continue
 				}
-				// Config-driven runs (no -E) are gated to DefaultComponents, which also
-				// leaves pseudo-keys like nccltest/pcie_topo in componentsToCheck for the
-				// after-loop special cases below. An explicit -E list is honored as-is so
-				// opt-in components (e.g. gpuprobe) can run; unknown -E names fail
-				// NewComponent and are skipped.
-				if len(enableComponents) == 0 && !slices.Contains(consts.DefaultComponents, componentName) {
+				// Config-driven runs (no -E) run DefaultComponents plus any component
+				// whose config section is enabled:true. This leaves pseudo-keys like
+				// nccltest/pcie_topo in componentsToCheck for the after-loop special
+				// cases below (they are not selected here). An explicit -E list is
+				// honored as-is so opt-in components (e.g. gpuprobe) can run; unknown
+				// -E names fail NewComponent and are skipped.
+				if len(enableComponents) == 0 && !SelectedInConfigMode(componentName, enabledOptIn) {
 					continue
 				}
 				wg.Add(1)

--- a/cmd/command/component/common.go
+++ b/cmd/command/component/common.go
@@ -91,6 +91,41 @@ func GetComponentsFromConfig(cfgFile string) ([]string, error) {
 	return components, nil
 }
 
+// EnabledOptInComponents returns the set of component config sections explicitly
+// turned on with `enable: true`. It lets a node opt a default-off component
+// (e.g. rdmaenv, gpuprobe) into a config-driven run without re-listing every
+// default via -E. The field is `enable` to match the existing convention
+// (sysinfo config, and the config-sync that writes `rdmaenv: {enable: true}` on
+// real nodes). Sections without a boolean `enable: true` are omitted; a load
+// error yields an empty set (no opt-in components), preserving default behavior.
+func EnabledOptInComponents(cfgFile string) map[string]bool {
+	var raw map[string]interface{}
+	if err := common.LoadUserConfig(cfgFile, &raw); err != nil {
+		return nil
+	}
+	out := make(map[string]bool)
+	for name, v := range raw {
+		section, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if enable, ok := section["enable"].(bool); ok && enable {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// SelectedInConfigMode reports whether a config-listed component should be
+// instantiated on a config-driven run (no -E flag): default components always
+// run, plus any component whose config section is `enabled: true`. Non-default,
+// non-enabled entries (including pseudo-keys like nccltest/pcie_topo) return
+// false so the NewComponent loop skips them, while they remain in the
+// component list for any after-loop special-case handling.
+func SelectedInConfigMode(name string, enabledOptIn map[string]bool) bool {
+	return slices.Contains(consts.DefaultComponents, name) || enabledOptIn[name]
+}
+
 // DetermineComponentsToCheck determines which components to check based on enable-components flag,
 // ignore-components flag, and the configuration file.
 // Parameters:

--- a/cmd/command/component/common_test.go
+++ b/cmd/command/component/common_test.go
@@ -433,3 +433,62 @@ func TestDetermineComponentsToCheck_EdgeCases(t *testing.T) {
 		}
 	}
 }
+
+// TestEnabledOptInComponents verifies that only config sections with a boolean
+// `enable: true` are reported as opt-in enabled. The field is `enable` to match
+// the existing convention (sysinfo config, and the config-sync that writes
+// `rdmaenv: {enable: true}` on real nodes).
+func TestEnabledOptInComponents(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cfg.yaml")
+	const cfg = `
+metrics:
+  port: 19091
+nvidia:
+  query_interval: 10s
+rdmaenv:
+  enable: true
+  endpoint: "http://127.0.0.1:19099/metrics"
+gpuprobe:
+  enable: false
+  query_interval: 600s
+`
+	if err := os.WriteFile(f, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	got := EnabledOptInComponents(f)
+	if !got["rdmaenv"] {
+		t.Errorf("rdmaenv (enable: true) should be opt-in enabled, got %v", got)
+	}
+	if got["gpuprobe"] {
+		t.Errorf("gpuprobe (enable: false) must not be opt-in enabled, got %v", got)
+	}
+	if got["nvidia"] {
+		t.Errorf("nvidia (no enable field) must not be in the opt-in set, got %v", got)
+	}
+}
+
+// TestSelectedInConfigMode verifies the config-driven (no -E) selection gate:
+// default components always run, opt-in components run only when enabled, and
+// pseudo-keys stay unselected (so the NewComponent loop skips them while they
+// remain available to after-loop special cases).
+func TestSelectedInConfigMode(t *testing.T) {
+	enabledOptIn := map[string]bool{"rdmaenv": true}
+	cases := []struct {
+		name string
+		comp string
+		want bool
+	}{
+		{"default component always selected", "nvidia", true},
+		{"opt-in with enabled:true selected", "rdmaenv", true},
+		{"opt-in without enable not selected", "gpuprobe", false},
+		{"pseudo-key nccltest not selected", "nccltest", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SelectedInConfigMode(c.comp, enabledOptIn); got != c.want {
+				t.Errorf("SelectedInConfigMode(%q) = %v, want %v", c.comp, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/command/daemon/run.go
+++ b/cmd/command/daemon/run.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"slices"
 	"time"
 
 	"github.com/scitix/sichek/cmd/command/component"
@@ -137,14 +136,17 @@ func NewDaemonRunCmd() *cobra.Command {
 			components := make(map[string]common.Component)
 
 			componentsToCheck := component.DetermineComponentsToCheck(usedComponentStr, ignoreComponentStr, cfgFile, "daemon")
+			enabledOptIn := component.EnabledOptInComponents(cfgFile)
 			for _, componentName := range componentsToCheck {
 				if componentName == consts.ComponentNameInfiniband && !utils.IsInfinibandExist() {
 					continue
 				}
-				// Config-driven runs (no -E) are gated to DefaultComponents. An explicit
-				// -E list is honored as-is so opt-in components (e.g. gpuprobe) can run;
-				// unknown -E names fail NewComponent and are skipped below.
-				if len(usedComponentStr) == 0 && !slices.Contains(consts.DefaultComponents, componentName) {
+				// Config-driven runs (no -E) run DefaultComponents plus any component
+				// whose config section is enabled:true, letting a node opt in an
+				// otherwise-default-off component (e.g. rdmaenv, gpuprobe) via config
+				// alone. An explicit -E list is honored as-is; unknown -E names fail
+				// NewComponent and are skipped below.
+				if len(usedComponentStr) == 0 && !component.SelectedInConfigMode(componentName, enabledOptIn) {
 					continue
 				}
 				component, err := component.NewComponent(componentName, cfgFile, specFile, nil)

--- a/components/common/spec.go
+++ b/components/common/spec.go
@@ -23,6 +23,7 @@ limitations under the License.
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -424,6 +425,17 @@ func httpDownload(fileURL, destPath string) error {
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("read body from %s: %w", fileURL, err)
+	}
+	// Guard against a 200 response with an empty/whitespace-only body. Object
+	// storage can briefly serve a zero-length 200 for an object that is being
+	// deleted or is mid-PUT (eventual consistency) before it settles to 404.
+	// Without this check os.WriteFile would faithfully install a 0-byte spec and
+	// the caller (DownloadSpecFile → EnsureSpecFile) would treat the download as
+	// successful, silently clobbering the previously-good canonical spec that
+	// every component shares. Returning an error here leaves the existing file
+	// untouched so EnsureSpecFile falls back to it.
+	if len(bytes.TrimSpace(data)) == 0 {
+		return fmt.Errorf("GET %s: empty response body (%d bytes), refusing to overwrite %s", fileURL, len(data), destPath)
 	}
 	return os.WriteFile(destPath, data, 0644)
 }

--- a/components/common/spec_test.go
+++ b/components/common/spec_test.go
@@ -137,6 +137,60 @@ func TestEnsureSpecFile_DownloadAndBackup(t *testing.T) {
 	}
 }
 
+// TestDownloadSpecFile_BadBodyPreservesExisting verifies that a 200-with-empty
+// body (as object storage briefly serves for an object mid-delete before it
+// settles to 404), a whitespace-only body, or a non-200 status all leave the
+// pre-existing canonical file untouched instead of clobbering it to garbage.
+func TestDownloadSpecFile_BadBodyPreservesExisting(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr bool
+	}{
+		{name: "empty_200", status: http.StatusOK, body: "", wantErr: true},
+		{name: "whitespace_200", status: http.StatusOK, body: "   \n\t\n", wantErr: true},
+		{name: "not_found", status: http.StatusNotFound, body: "", wantErr: true},
+		{name: "good_200", status: http.StatusOK, body: "name: remote\nversion: v2\n", wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			defer srv.Close()
+
+			dir := t.TempDir()
+			destPath := filepath.Join(dir, "some_spec.yaml")
+			writeTmpYAMLTo(t, destPath, itemSpec{Name: "original"})
+
+			err := DownloadSpecFile(srv.URL+"/some_spec.yaml", destPath, "test")
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var got itemSpec
+			if err := LoadSpec(destPath, &got); err != nil {
+				t.Fatalf("canonical file unreadable after download: %v", err)
+			}
+			if tc.wantErr {
+				// The good original must survive a rejected download.
+				if got.Name != "original" {
+					t.Errorf("existing spec was clobbered: got %+v", got)
+				}
+			} else {
+				if got.Name != "remote" {
+					t.Errorf("good download not applied: got %+v", got)
+				}
+			}
+		})
+	}
+}
+
 // ─── FilterSpec ──────────────────────────────────────────────────────────────
 
 func filterItem(c *multiItemSpec, id string) (*itemSpec, bool) {

--- a/components/lldp/lldp.go
+++ b/components/lldp/lldp.go
@@ -18,7 +18,6 @@ package lldp
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -217,29 +216,18 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 		return true
 	}
 
-	hostname, _ := os.Hostname()
-
-	// Separate real switch uplinks from self/loopback and host neighbors.
-	// A switch advertises its port as an "ifname"; OVS VF representors loop
-	// back to our own hostname and host-to-host neighbors identify their port
-	// by MAC. The latter are not switch uplinks, so they are folded away.
-	var uplinks []collector.IfaceInfo
-	var folded []string
-	for _, iface := range lldpInfo.Interfaces {
-		if isSwitchUplink(iface, hostname) {
-			uplinks = append(uplinks, iface)
-		} else {
-			folded = append(folded, iface.Local.Name)
-		}
-	}
-
-	fmt.Printf("%sLLDP neighbors: %d switch uplink(s)%s\n", consts.Green, len(uplinks), consts.Reset)
+	// List every LLDP neighbor lldpctl reported, one row per local interface.
+	// No folding: self/loopback and host-to-host neighbors are shown too, since
+	// the previous "switch uplink only" filter also hid real rail-switch uplinks
+	// on OVS/multi-plane nodes (switches that advertise their port as "local"
+	// rather than "ifname").
+	fmt.Printf("%sLLDP neighbors: %d%s\n", consts.Green, len(lldpInfo.Interfaces), consts.Reset)
 	fmt.Printf(lldpRowFmt, "Local Port", "Link", "Local IP", "MTU", "Neighbor Switch",
 		"Chassis ID", "Mgmt IP", "Remote Port", "VLAN", "Capability", "MFS", "Age")
 	fmt.Printf(lldpRowFmt, dashes(20), dashes(5), dashes(19), dashes(6), dashes(16),
 		dashes(18), dashes(16), dashes(22), dashes(6), dashes(14), dashes(6), dashes(9))
 
-	for _, iface := range uplinks {
+	for _, iface := range lldpInfo.Interfaces {
 		l := iface.Local
 		n := iface.Neighbor
 		local := l.Name
@@ -261,19 +249,8 @@ func (c *component) PrintInfo(info common.Info, result *common.Result, summaryPr
 			fmtAge(n.AgeSeconds),
 		)
 	}
-
-	if len(folded) > 0 {
-		fmt.Printf("\n%d local/loopback or host neighbor(s) hidden: %s\n",
-			len(folded), strings.Join(folded, ", "))
-	}
 	fmt.Println()
 	return true
-}
-
-// isSwitchUplink reports whether an LLDP neighbor is a real switch uplink
-// (as opposed to a self VF-representor loopback or a host-to-host link).
-func isSwitchUplink(iface collector.IfaceInfo, hostname string) bool {
-	return collector.IsSwitchNeighbor(iface.Neighbor, hostname)
 }
 
 func dashes(n int) string { return strings.Repeat("-", n) }

--- a/components/lldp/lldp_test.go
+++ b/components/lldp/lldp_test.go
@@ -63,7 +63,7 @@ func TestIsSwitchUplink(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			assert.Equal(t, c.want, isSwitchUplink(c.iface, hostname))
+			assert.Equal(t, c.want, collector.IsSwitchNeighbor(c.iface.Neighbor, hostname))
 		})
 	}
 }

--- a/config/default_user_config.yaml
+++ b/config/default_user_config.yaml
@@ -6,7 +6,7 @@ snapshot:
   path: "/var/sichek/data/snapshot.json"
 
 reporter:
-  enable: false  # master switch; flip to true after deploying sichek-collector
+  enable: true  # master switch; flip to true after deploying sichek-collector
   endpoint: "http://10.155.30.38:38080/api/v1/snapshots"
   interval: 60s
   timeout: 30s
@@ -110,17 +110,22 @@ sysinfo:
     #   path: scripts/gpu/collect-gpu.sh
     #   interval: 12h
 
-# gpuprobe is default-off (not in consts.DefaultComponents); this section only
-# lets it load when explicitly enabled via `-E gpuprobe` or `sichek gpu_probe`.
+# gpuprobe is default-off (not in consts.DefaultComponents). Set `enable: true`
+# here to run it on a config-driven daemon (no -E needed), or run it ad hoc via
+# `-E gpuprobe` / `sichek gpu_probe`.
 gpuprobe:
+  enable: true
   query_interval: 600s
   cache_size: 5
   enable_metrics: true
 
-# rdmaenv is default-off (not in consts.DefaultComponents); this section only
-# lets it load when explicitly enabled via `-E rdmaenv` or `sichek rdmaenv`.
-# It scrapes the co-located rdma-env-pre exporter and passes its metrics through.
+# rdmaenv is default-off (not in consts.DefaultComponents). Set `enable: true`
+# here to run it on a config-driven daemon (no -E needed), or run it ad hoc via
+# `-E rdmaenv` / `sichek rdmaenv`. It scrapes the co-located rdma-env-pre exporter
+# and passes its metrics through; `enable_metrics` must stay true to re-export
+# them on sichek's own /metrics.
 rdmaenv:
+  enable: true
   query_interval: 10m
   endpoint: "http://127.0.0.1:19099/metrics"
   timeout: 10s

--- a/scripts/check_sicl.sh
+++ b/scripts/check_sicl.sh
@@ -22,10 +22,11 @@ if [ -f "$SICL_PACKAGED_PATH" ]; then
     chmod +x "$SICL_PACKAGED_PATH"
     
     echo "[sichek postinstall] Running packaged installer..."
-    bash "$SICL_PACKAGED_PATH"
-    
-    if [ $? -eq 0 ]; then
+    if bash "$SICL_PACKAGED_PATH"; then
         echo "[sichek postinstall] SICL installed successfully from packaged installer."
+        # Remove the bundled installer (hundreds of MB) to reclaim disk space.
+        echo "[sichek postinstall] Cleaning up packaged installer at $SICL_PACKAGED_PATH..."
+        rm -f "$SICL_PACKAGED_PATH"
         exit 0
     else
         echo "[sichek postinstall] Packaged installer failed, trying network download..."
@@ -42,12 +43,7 @@ fi
 chmod +x "$SICL_INSTALLER_LOCAL"
 
 echo "[sichek postinstall] Running installer..."
-bash "$SICL_INSTALLER_LOCAL"
-
-echo "[check_sicl] Cleaning up installer..."
-rm -f "$SICL_INSTALLER_LOCAL"
-
-if [ $? -ne 0 ]; then
+if ! bash "$SICL_INSTALLER_LOCAL"; then
     echo "[sichek postinstall] SICL ${SICL_PKG_NAME} installation failed."
     exit 1
 fi

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -5,6 +5,19 @@
 
 set -e
 
+# The package ships /etc/systemd/system/sichek.service. Reload systemd so the unit
+# is picked up, then enable it so sichek starts automatically on the next boot.
+# We enable but do NOT start: launching the 8-GPU health daemon at install / image-
+# bake time is unwanted, so we let the first real boot bring it up.
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+    # Enable (but do NOT start) so sichek comes up on the next boot. We intentionally
+    # skip `start` here: at install / image-bake time we must not launch the 8-GPU
+    # health daemon. The first real boot brings it up via WantedBy=multi-user.target.
+    systemctl enable sichek.service || true
+    systemctl start sichek.service || true
+fi
+
 SICHEK_SCRIPTS_PATH="/var/sichek/scripts"
 PROFILE_D_FILE="/etc/profile.d/sichek.sh"
 


### PR DESCRIPTION
## What

Let a node opt a default-off component (e.g. `rdmaenv`, `gpuprobe`) into a
config-driven daemon/all run via `enable: true` in its config section — no
`-E <comp>` needed. Default components still always run; an explicit `-E`
list is still honored as-is.

### Changes
- **Config opt-in gate** (`cmd/command/component/common.go`)
  - `EnabledOptInComponents(cfg)` — collects sections with `enable: true`.
  - `SelectedInConfigMode(name, optIn)` — DefaultComponents ∪ opt-in set;
    pseudo-keys (nccltest/pcie_topo) stay in the list for after-loop handling
    but are not instantiated here.
  - Wired into both `all.go` and `daemon/run.go` selection loops (replaces the
    old `DefaultComponents`-only gate).
- **spec download: refuse empty 200 body** (`components/common/spec.go`)
  - Object storage can briefly serve a 0-byte 200 for an object mid-delete/PUT;
    without this guard a good shared canonical spec gets silently clobbered.
    Now returns an error so EnsureSpecFile falls back to the existing file.
- **LLDP: list every neighbor** (`components/lldp/lldp.go`)
  - Drops the "switch-uplink only" fold that also hid real rail-switch uplinks
    on OVS/multi-plane nodes.
- **Packaging** (`.goreleaser.yaml`, `scripts/`)
  - Ship `sichek.service` in the deb; postinstall runs `daemon-reload` (+enable/start).
  - `check_sicl.sh` removes the bundled/downloaded SICL installer after install.