### PR TITLE
feat(infiniband): add check_ib_mezz_name — validate mezz card RDMA naming

### DIFF
--- a/components/infiniband/checker/checker.go
+++ b/components/infiniband/checker/checker.go
@@ -41,6 +41,7 @@ func NewCheckers(cfg *config.InfinibandUserConfig, spec *config.InfinibandSpec) 
 		config.CheckIBDriver:    NewIBDriverChecker,
 		config.CheckIBLost:      NewIBLostChecker,
 		config.CheckIBRailCount: NewIBRailCountChecker,
+		config.CheckIBMezzName:  NewIBMezzNameChecker,
 		config.CheckRoCE:        NewRoCEChecker,
 		config.CheckPCIETreeSpeed: NewIBPCIETreeSpeedChecker,
 		config.CheckPCIETreeWidth: NewIBPCIETreeWidthChecker,

--- a/components/infiniband/checker/mezz_name.go
+++ b/components/infiniband/checker/mezz_name.go
@@ -41,9 +41,10 @@ const defaultIBSysDir = "/sys/class/infiniband"
 // this checker exists to catch.
 var mezzNameRe = regexp.MustCompile(`^mezz_\d+$`)
 
-// IBMezzNameChecker verifies that every mezz card (identified solely by board_id
-// config.MezzBoardID, per rdma-env-pre docs/mezz-card-identification.md) has its
-// RDMA device named per the mezz_<k> convention.
+// IBMezzNameChecker verifies that every mezz card (identified solely by its
+// board_id being in config.MezzBoardIDs, per rdma-env-pre
+// docs/mezz-card-identification.md) has its RDMA device named per the mezz_<k>
+// convention.
 //
 // It is deliberately spec-free: it reads sysfs directly rather than the collected
 // InfinibandInfo, so its verdict is identical whether it runs on the healthy path
@@ -72,7 +73,7 @@ func MezzNamingResult() *common.CheckerResult {
 }
 
 // mezzNamingResultAt is the testable core: it scans sysRoot (…/sys/class/infiniband)
-// for mezz cards (board_id == config.MezzBoardID) and checks each one's device
+// for mezz cards (board_id in config.MezzBoardIDs) and checks each one's device
 // directory name against mezz_<k>. Non-mezz devices are ignored; a host with no
 // mezz card (or no IB sysfs at all) passes.
 func mezzNamingResultAt(sysRoot string) *common.CheckerResult {
@@ -91,7 +92,7 @@ func mezzNamingResultAt(sysRoot string) *common.CheckerResult {
 	var bad []string
 	for _, e := range entries {
 		dev := e.Name()
-		if readSysAttr(filepath.Join(sysRoot, dev, "board_id")) != config.MezzBoardID {
+		if !config.MezzBoardIDs[readSysAttr(filepath.Join(sysRoot, dev, "board_id"))] {
 			continue // not a mezz card
 		}
 		netdev := mezzNetdevName(dev) // mezz_0 -> mezz0 (display only, not validated)

--- a/components/infiniband/checker/mezz_name.go
+++ b/components/infiniband/checker/mezz_name.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/scitix/sichek/components/common"
+	"github.com/scitix/sichek/components/infiniband/config"
+	"github.com/scitix/sichek/consts"
+)
+
+// defaultIBSysDir is the sysfs root that enumerates InfiniBand devices. Each
+// entry directory name is the RDMA device name itself, so the mezz naming check
+// needs nothing but this tree — no HCA spec, no heavy collector.
+const defaultIBSysDir = "/sys/class/infiniband"
+
+// mezzNameRe is the naming convention rdma-env-pre's interface-naming applies to
+// a mezz card's RDMA device: mezz_<k>. A mezz card (board_id config.MezzBoardID)
+// whose device name does not match this has not been named, which is the failure
+// this checker exists to catch.
+var mezzNameRe = regexp.MustCompile(`^mezz_\d+$`)
+
+// IBMezzNameChecker verifies that every mezz card (identified solely by board_id
+// config.MezzBoardID, per rdma-env-pre docs/mezz-card-identification.md) has its
+// RDMA device named per the mezz_<k> convention.
+//
+// It is deliberately spec-free: it reads sysfs directly rather than the collected
+// InfinibandInfo, so its verdict is identical whether it runs on the healthy path
+// (via common.Check) or is invoked directly from the IB component's initError
+// path. That matters because the mezz board_id has no HCA spec by design, which
+// otherwise puts the whole IB component into initError where no normal checker runs.
+type IBMezzNameChecker struct {
+	name string
+}
+
+func NewIBMezzNameChecker(_ *config.InfinibandSpec) (common.Checker, error) {
+	return &IBMezzNameChecker{name: config.CheckIBMezzName}, nil
+}
+
+func (c *IBMezzNameChecker) Name() string { return c.name }
+
+// Check ignores the collected data on purpose and performs its own sysfs scan so
+// the healthy path and the initError path share one implementation.
+func (c *IBMezzNameChecker) Check(_ context.Context, _ any) (*common.CheckerResult, error) {
+	return MezzNamingResult(), nil
+}
+
+// MezzNamingResult runs the mezz naming check against the live sysfs tree.
+func MezzNamingResult() *common.CheckerResult {
+	return mezzNamingResultAt(defaultIBSysDir)
+}
+
+// mezzNamingResultAt is the testable core: it scans sysRoot (…/sys/class/infiniband)
+// for mezz cards (board_id == config.MezzBoardID) and checks each one's device
+// directory name against mezz_<k>. Non-mezz devices are ignored; a host with no
+// mezz card (or no IB sysfs at all) passes.
+func mezzNamingResultAt(sysRoot string) *common.CheckerResult {
+	result := config.InfinibandCheckItems[config.CheckIBMezzName]
+
+	entries, err := os.ReadDir(sysRoot)
+	if err != nil {
+		// No IB sysfs -> nothing to check. Treat as normal so non-IB hosts and
+		// hosts without a mezz card do not raise a false Critical.
+		result.Status = consts.StatusNormal
+		result.Detail = "no infiniband devices found"
+		return &result
+	}
+
+	var lines []string
+	var bad []string
+	for _, e := range entries {
+		dev := e.Name()
+		if readSysAttr(filepath.Join(sysRoot, dev, "board_id")) != config.MezzBoardID {
+			continue // not a mezz card
+		}
+		netdev := mezzNetdevName(dev) // mezz_0 -> mezz0 (display only, not validated)
+		link := mezzLinkLabel(sysRoot, dev)
+		if mezzNameRe.MatchString(dev) {
+			lines = append(lines, fmt.Sprintf("%s port 1 ==> %s (%s)", dev, netdev, link))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s port 1 ==> %s (%s)  [expected mezz_<k>]", dev, netdev, link))
+			bad = append(bad, dev)
+		}
+	}
+
+	sort.Strings(lines)
+	if len(bad) > 0 {
+		sort.Strings(bad)
+		result.Status = consts.StatusAbnormal
+		result.Device = strings.Join(bad, ",")
+		result.Detail = strings.Join(lines, "\n")
+		return &result
+	}
+
+	result.Status = consts.StatusNormal
+	if len(lines) == 0 {
+		result.Detail = "no mezz card found"
+	} else {
+		result.Detail = strings.Join(lines, "\n")
+	}
+	return &result
+}
+
+// readSysAttr reads a sysfs attribute file and trims trailing whitespace/newline.
+// A read error yields "" so callers can compare against expected values simply.
+func readSysAttr(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// mezzNetdevName derives the netdev display name (mezz<k>) from the RDMA device
+// name (mezz_<k>). Display only — the checker validates the RDMA name, not this.
+// A non-conforming input is returned unchanged.
+func mezzNetdevName(rdmaDev string) string {
+	return strings.Replace(rdmaDev, "mezz_", "mezz", 1)
+}
+
+// mezzLinkLabel reads the device's port-1 phys_state and reduces it to Up/Down.
+// sysfs phys_state reads like "5: LinkUp" / "2: Polling" / "3: Disabled"; anything
+// that is not LinkUp is reported as Down.
+func mezzLinkLabel(sysRoot, dev string) string {
+	state := readSysAttr(filepath.Join(sysRoot, dev, "ports", "1", "phys_state"))
+	if strings.Contains(state, "LinkUp") {
+		return "Up"
+	}
+	return "Down"
+}

--- a/components/infiniband/checker/mezz_name_test.go
+++ b/components/infiniband/checker/mezz_name_test.go
@@ -45,7 +45,11 @@ func writeIBSysfs(t *testing.T, root string, devs map[string]fakeDev) {
 }
 
 func TestMezzNamingResultAt(t *testing.T) {
-	const cx7Board = "MT_0000000834" // a non-mezz HCA board_id
+	const (
+		b300Mezz = "NVD0000000079" // B300 mezz board_id
+		b200Mezz = "MT_0000001121" // B200 mezz board_id
+		cx7Board = "MT_0000000834" // a non-mezz HCA board_id
+	)
 
 	tests := []struct {
 		name       string
@@ -58,8 +62,8 @@ func TestMezzNamingResultAt(t *testing.T) {
 		{
 			name: "mezz named correctly -> normal",
 			devs: map[string]fakeDev{
-				"mezz_0": {config.MezzBoardID, "5: LinkUp"},
-				"mezz_1": {config.MezzBoardID, "2: Polling"},
+				"mezz_0": {b300Mezz, "5: LinkUp"},
+				"mezz_1": {b300Mezz, "2: Polling"},
 			},
 			wantStatus: consts.StatusNormal,
 			wantDetail: []string{"mezz_0 port 1 ==> mezz0 (Up)", "mezz_1 port 1 ==> mezz1 (Down)"},
@@ -67,11 +71,29 @@ func TestMezzNamingResultAt(t *testing.T) {
 		{
 			name: "mezz misnamed -> critical abnormal",
 			devs: map[string]fakeDev{
-				"mlx5_9": {config.MezzBoardID, "2: Polling"},
+				"mlx5_9": {b300Mezz, "2: Polling"},
 			},
 			wantStatus: consts.StatusAbnormal,
 			wantDevice: "mlx5_9",
 			wantDetail: []string{"mlx5_9 port 1 ==> mlx5_9 (Down)", "expected mezz_<k>"},
+		},
+		{
+			name: "B200 mezz board_id also recognized, named correctly -> normal",
+			devs: map[string]fakeDev{
+				"mezz_0": {b200Mezz, "5: LinkUp"},
+				"mezz_1": {b200Mezz, "5: LinkUp"},
+			},
+			wantStatus: consts.StatusNormal,
+			wantDetail: []string{"mezz_0 port 1 ==> mezz0 (Up)", "mezz_1 port 1 ==> mezz1 (Up)"},
+		},
+		{
+			name: "B200 mezz misnamed -> critical abnormal",
+			devs: map[string]fakeDev{
+				"mlx5_8": {b200Mezz, "2: Polling"},
+			},
+			wantStatus: consts.StatusAbnormal,
+			wantDevice: "mlx5_8",
+			wantDetail: []string{"mlx5_8 port 1 ==> mlx5_8 (Down)", "expected mezz_<k>"},
 		},
 		{
 			name: "no mezz card (only CX7) -> normal",
@@ -84,8 +106,8 @@ func TestMezzNamingResultAt(t *testing.T) {
 		{
 			name: "mixed: one good one bad -> abnormal, only bad reported",
 			devs: map[string]fakeDev{
-				"mezz_0":  {config.MezzBoardID, "5: LinkUp"},
-				"badmezz": {config.MezzBoardID, "5: LinkUp"},
+				"mezz_0":  {b300Mezz, "5: LinkUp"},
+				"badmezz": {b300Mezz, "5: LinkUp"},
 				"mlx5_0":  {cx7Board, "5: LinkUp"},
 			},
 			wantStatus: consts.StatusAbnormal,

--- a/components/infiniband/checker/mezz_name_test.go
+++ b/components/infiniband/checker/mezz_name_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Scitix Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scitix/sichek/components/infiniband/config"
+	"github.com/scitix/sichek/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDev struct {
+	boardID   string
+	physState string
+}
+
+// writeIBSysfs builds a fake /sys/class/infiniband tree: one dir per device with
+// a board_id file and a ports/1/phys_state file.
+func writeIBSysfs(t *testing.T, root string, devs map[string]fakeDev) {
+	t.Helper()
+	for dev, d := range devs {
+		portDir := filepath.Join(root, dev, "ports", "1")
+		require.NoError(t, os.MkdirAll(portDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, dev, "board_id"), []byte(d.boardID+"\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(portDir, "phys_state"), []byte(d.physState+"\n"), 0o644))
+	}
+}
+
+func TestMezzNamingResultAt(t *testing.T) {
+	const cx7Board = "MT_0000000834" // a non-mezz HCA board_id
+
+	tests := []struct {
+		name       string
+		devs       map[string]fakeDev
+		wantStatus string
+		wantDevice string
+		// substrings expected in Detail
+		wantDetail []string
+	}{
+		{
+			name: "mezz named correctly -> normal",
+			devs: map[string]fakeDev{
+				"mezz_0": {config.MezzBoardID, "5: LinkUp"},
+				"mezz_1": {config.MezzBoardID, "2: Polling"},
+			},
+			wantStatus: consts.StatusNormal,
+			wantDetail: []string{"mezz_0 port 1 ==> mezz0 (Up)", "mezz_1 port 1 ==> mezz1 (Down)"},
+		},
+		{
+			name: "mezz misnamed -> critical abnormal",
+			devs: map[string]fakeDev{
+				"mlx5_9": {config.MezzBoardID, "2: Polling"},
+			},
+			wantStatus: consts.StatusAbnormal,
+			wantDevice: "mlx5_9",
+			wantDetail: []string{"mlx5_9 port 1 ==> mlx5_9 (Down)", "expected mezz_<k>"},
+		},
+		{
+			name: "no mezz card (only CX7) -> normal",
+			devs: map[string]fakeDev{
+				"mlx5_0": {cx7Board, "5: LinkUp"},
+			},
+			wantStatus: consts.StatusNormal,
+			wantDetail: []string{"no mezz card found"},
+		},
+		{
+			name: "mixed: one good one bad -> abnormal, only bad reported",
+			devs: map[string]fakeDev{
+				"mezz_0":  {config.MezzBoardID, "5: LinkUp"},
+				"badmezz": {config.MezzBoardID, "5: LinkUp"},
+				"mlx5_0":  {cx7Board, "5: LinkUp"},
+			},
+			wantStatus: consts.StatusAbnormal,
+			wantDevice: "badmezz",
+			wantDetail: []string{"mezz_0 port 1 ==> mezz0 (Up)", "badmezz port 1 ==> badmezz (Up)  [expected mezz_<k>]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeIBSysfs(t, root, tt.devs)
+
+			got := mezzNamingResultAt(root)
+
+			assert.Equal(t, config.CheckIBMezzName, got.Name)
+			assert.Equal(t, consts.LevelCritical, got.Level)
+			assert.Equal(t, tt.wantStatus, got.Status)
+			assert.Equal(t, tt.wantDevice, got.Device)
+			for _, sub := range tt.wantDetail {
+				assert.Contains(t, got.Detail, sub)
+			}
+		})
+	}
+}
+
+// A host with no IB sysfs at all must pass (non-IB nodes, or IB stack not up).
+func TestMezzNamingResultAt_NoSysfs(t *testing.T) {
+	got := mezzNamingResultAt(filepath.Join(t.TempDir(), "does-not-exist"))
+	assert.Equal(t, consts.StatusNormal, got.Status)
+	assert.Equal(t, "no infiniband devices found", got.Detail)
+}

--- a/components/infiniband/config/check_items.go
+++ b/components/infiniband/config/check_items.go
@@ -40,7 +40,15 @@ const (
 	CheckPCIETreeWidth = "check_pcie_tree_width"
 	CheckIBLost        = "check_ib_lost"
 	CheckIBRailCount   = "check_ib_rail_count"
+	CheckIBMezzName    = "check_ib_mezz_name"
 )
+
+// MezzBoardID is the firmware PSID (board_id) that uniquely identifies an internal
+// IB mezzanine card. Per rdma-env-pre docs/mezz-card-identification.md this is the
+// only reliable discriminator: mezz and CX7 both report PCI device 0x1021, so only
+// board_id tells them apart. A mezz card has no HCA spec by design (it is
+// identified but never configured).
+const MezzBoardID = "NVD0000000079"
 
 var InfinibandCheckItems = map[string]common.CheckerResult{
 	CheckIBOFED: {
@@ -170,5 +178,13 @@ var InfinibandCheckItems = map[string]common.CheckerResult{
 		Detail:      "Compute-rail HCA count is plausible",
 		ErrorName:   "IBRailCountOdd",
 		Suggestion:  "An odd rail count usually means an HCA vanished from the RDMA stack; compare against the node's expected topology and check dmesg for mlx5_core probe failures",
+	},
+	CheckIBMezzName: {
+		Name:        CheckIBMezzName,
+		Description: "Check that each mezz card (board_id NVD0000000079) RDMA device is named mezz_<k>",
+		Level:       consts.LevelCritical,
+		Detail:      "All mezz cards are named per the mezz_<k> convention",
+		ErrorName:   "IBMezzNameMismatch",
+		Suggestion:  "The mezz card was not renamed to mezz_<k>; ensure rdma-env-pre interface-naming ran on this node",
 	},
 }

--- a/components/infiniband/config/check_items.go
+++ b/components/infiniband/config/check_items.go
@@ -43,12 +43,16 @@ const (
 	CheckIBMezzName    = "check_ib_mezz_name"
 )
 
-// MezzBoardID is the firmware PSID (board_id) that uniquely identifies an internal
-// IB mezzanine card. Per rdma-env-pre docs/mezz-card-identification.md this is the
-// only reliable discriminator: mezz and CX7 both report PCI device 0x1021, so only
-// board_id tells them apart. A mezz card has no HCA spec by design (it is
-// identified but never configured).
-const MezzBoardID = "NVD0000000079"
+// MezzBoardIDs is the set of firmware PSIDs (board_ids) that identify an internal
+// IB mezzanine card. Per rdma-env-pre docs/mezz-card-identification.md board_id is
+// the only reliable discriminator: mezz and CX7 both report PCI device 0x1021, so
+// only board_id tells them apart. The board_id is generation-specific, so this set
+// must be extended as new GPU generations ship. A mezz card has no HCA spec by
+// design (it is identified but never configured).
+var MezzBoardIDs = map[string]bool{
+	"NVD0000000079": true, // B300
+	"MT_0000001121": true, // B200
+}
 
 var InfinibandCheckItems = map[string]common.CheckerResult{
 	CheckIBOFED: {

--- a/components/infiniband/infiniband.go
+++ b/components/infiniband/infiniband.go
@@ -177,7 +177,13 @@ func (c *component) Name() string {
 
 func (c *component) HealthCheck(ctx context.Context) (*common.Result, error) {
 	if c.initError != nil {
-		return c.reportInitErrorResult(), nil
+		// The mezz naming check is spec-free by design: run it even here so a
+		// mezz card whose board_id has no HCA spec (which is what drove the
+		// component into initError) still gets its naming validated instead of
+		// being silently skipped along with every other checker.
+		result := c.reportInitErrorResult()
+		result.Checkers = append(result.Checkers, checker.MezzNamingResult())
+		return result, nil
 	}
 
 	info, err := c.collector.Collect(ctx)

--- a/components/infiniband/infiniband.go
+++ b/components/infiniband/infiniband.go
@@ -180,9 +180,14 @@ func (c *component) HealthCheck(ctx context.Context) (*common.Result, error) {
 		// The mezz naming check is spec-free by design: run it even here so a
 		// mezz card whose board_id has no HCA spec (which is what drove the
 		// component into initError) still gets its naming validated instead of
-		// being silently skipped along with every other checker.
+		// being silently skipped along with every other checker. Only surface it
+		// when it actually failed: the initError-path PrintInfo renders every
+		// appended checker as a red error, so a passing/no-mezz result would read
+		// as a spurious failure.
 		result := c.reportInitErrorResult()
-		result.Checkers = append(result.Checkers, checker.MezzNamingResult())
+		if mezz := checker.MezzNamingResult(); mezz.Status == consts.StatusAbnormal {
+			result.Checkers = append(result.Checkers, mezz)
+		}
 		return result, nil
 	}
 

--- a/docs/superpowers/specs/2026-09-02-ib-mezz-name-checker-design.md
+++ b/docs/superpowers/specs/2026-09-02-ib-mezz-name-checker-design.md
@@ -10,7 +10,18 @@
 
 ## mezz 卡的判据(硬编码)
 
-依据 `rdma-env-pre` 文档 `docs/mezz-card-identification.md`:**mezz 的唯一判据是 board_id(固件 PSID)`NVD0000000079`**。PCI vendor:device(`0x1021`)与 CX7 相同,不能用来区分,只有 board_id 能分开。因此本检查以硬编码常量 `MezzBoardID = "NVD0000000079"` 锚定 mezz 卡。
+依据 `rdma-env-pre` 文档 `docs/mezz-card-identification.md`:**mezz 的判据是 board_id(固件 PSID)**。PCI vendor:device(`0x1021`)与 CX7 相同,不能用来区分,只有 board_id 能分开。
+
+board_id **跨 GPU 代不同**,因此以硬编码集合锚定:
+
+```go
+var MezzBoardIDs = map[string]bool{
+    "NVD0000000079": true, // B300 (gpu-10-220-55-90 实测)
+    "MT_0000001121": true, // B200 (gpu-10-220-55-7 实测)
+}
+```
+
+新代出货需在此扩充。注意上游 `rdma-env-pre` 的 `internal-mezz-ib.json` 目前只声明 `NVD0000000079`,B200 的 `MT_0000001121` 由真机 B200 节点实测得到(4 张命名为 `mezz_0..3` 的内部卡,board_id 一致,与 compute HCA `MT_0000000838` 分离),应与上游 owner 对齐后同步维护。
 
 ## 关键约束:不依赖 spec、不走 spec-gated 路径
 
@@ -46,7 +57,7 @@ IB 组件在 `newInfinibandComponent` 里先 `LoadSpec`(→ `FilterSpec`);当某
 ## 两条运行路径(方案 A)
 
 1. **正常路径**:注册为普通 IB checker(`NewIBMezzNameChecker`),`Check(ctx, data)` 忽略传入 data、直接调 `mezzNamingResultAt` 默认根,随 `common.Check` 与其它 checker 一起跑。
-2. **initError 路径**:在 `HealthCheck` 的 `if c.initError != nil` 分支里,把 `mezzNamingResultAt` 的结果 append 进 `reportInitErrorResult()` 的 `Checkers`,并在 mezz 判 Critical-abnormal 时确保返回结果的 `Status/Level` 反映出来。
+2. **initError 路径**:在 `HealthCheck` 的 `if c.initError != nil` 分支里调 `MezzNamingResult()`,**仅当结果为 abnormal 时**才 append 进 `reportInitErrorResult()` 的 `Checkers`。原因:initError 分支的 `PrintInfo` 会把结果里每个 checker 无条件标红并打 `ErrorName`,若把一个 Normal/无-mezz 的结果也 append 进去,会被渲染成误导性的红色"失败"行。因此只在 mezz 命名**真的失败**时才在此路径浮现。
 
 两条路径调用同一个 `mezzNamingResultAt`,判定完全一致。**不改 `FilterSpec`;只在 HealthCheck 的 initError 分支加几行独立调用。**
 

--- a/docs/superpowers/specs/2026-09-02-ib-mezz-name-checker-design.md
+++ b/docs/superpowers/specs/2026-09-02-ib-mezz-name-checker-design.md
@@ -1,0 +1,78 @@
+# check_ib_mezz_name — mezz 卡命名一致性检查
+
+日期:2026-09-02
+组件:`components/infiniband`
+分支:`feat/ib-mezz-name-checker`
+
+## 目标
+
+新增一个 InfiniBand 检查项,校验每张 **mezz 卡**(内部 IB mezzanine 卡)的 RDMA 设备名是否符合 `mezz_<k>` 命名约定。命名不符说明上游 `rdma-env-pre` 的 `interface-naming` 没有生效,判 **Critical**。
+
+## mezz 卡的判据(硬编码)
+
+依据 `rdma-env-pre` 文档 `docs/mezz-card-identification.md`:**mezz 的唯一判据是 board_id(固件 PSID)`NVD0000000079`**。PCI vendor:device(`0x1021`)与 CX7 相同,不能用来区分,只有 board_id 能分开。因此本检查以硬编码常量 `MezzBoardID = "NVD0000000079"` 锚定 mezz 卡。
+
+## 关键约束:不依赖 spec、不走 spec-gated 路径
+
+IB 组件在 `newInfinibandComponent` 里先 `LoadSpec`(→ `FilterSpec`);当某个检测到的 board_id 在 HCA spec 里查不到时,`FilterSpec` 返回 `spec not found for board IDs`,组件进入 `initError`。此时 `HealthCheck` 开头 `if c.initError != nil { return c.reportInitErrorResult() }` 直接返回,**collect 与所有 checker 都不跑**。mezz 的 board_id `NVD0000000079` 恰恰常常不在下发 spec 里(它本就不该有 HCA spec),于是普通 checker 在 mezz 节点上根本跑不到。
+
+**本设计不修改 `FilterSpec`**。mezz 命名检查做成一条**完全不依赖 spec、也不依赖重采集器**的独立路径:
+
+- IB 设备名 = `/sys/class/infiniband/<name>/` 的目录名;
+- board_id = `/sys/class/infiniband/<name>/board_id`;
+- 端口状态(仅展示用)= `/sys/class/infiniband/<name>/ports/1/phys_state`。
+
+纯 sysfs 扫描即可完成判定,无需 `InfinibandSpec`、无需 `NewIBCollector`。
+
+## 判定逻辑
+
+函数 `mezzNamingResultAt(sysRoot string) *common.CheckerResult`(默认 `sysRoot=/sys/class/infiniband`):
+
+1. 遍历 `sysRoot` 下每个 IB 设备目录 `<name>`;
+2. 读 `<name>/board_id`,`TrimSpace` 后 `== MezzBoardID` 才纳入(非 mezz 全忽略);
+3. 名字匹配正则 `^mezz_\d+$` → 命名对上;否则记为不符;
+4. **有任一 mezz 命名不符 → Status=Abnormal / Level=Critical**;无 mezz 卡、或全部对上 → Normal;
+5. Detail 逐张列出映射,格式对齐用户样例:`mezz_0 port 1 ==> mezz0 (Down)`
+   - netdev 名 `mezz0` 由 `mezz_0` 约定推导(`mezz_`→`mezz`),**仅展示,不参与校验**;
+   - `(Down)` 由 `phys_state != LINK_UP`(sysfs 返回如 `5: LinkUp` / `2: Polling` / `3: Disabled`)推导;
+   - 命名不符的行额外标 `expected mezz_<k>`;
+6. `Device` = 命名不符的设备名(逗号连接),供上层聚合定位。
+
+结果模板放进 `InfinibandCheckItems`:
+- `Level = consts.LevelCritical`
+- `ErrorName = "IBMezzNameMismatch"`
+- `Suggestion` = 提示 `rdma-env-pre interface-naming` 未生效,mezz 的 RDMA 设备应命名为 `mezz_<k>`
+
+## 两条运行路径(方案 A)
+
+1. **正常路径**:注册为普通 IB checker(`NewIBMezzNameChecker`),`Check(ctx, data)` 忽略传入 data、直接调 `mezzNamingResultAt` 默认根,随 `common.Check` 与其它 checker 一起跑。
+2. **initError 路径**:在 `HealthCheck` 的 `if c.initError != nil` 分支里,把 `mezzNamingResultAt` 的结果 append 进 `reportInitErrorResult()` 的 `Checkers`,并在 mezz 判 Critical-abnormal 时确保返回结果的 `Status/Level` 反映出来。
+
+两条路径调用同一个 `mezzNamingResultAt`,判定完全一致。**不改 `FilterSpec`;只在 HealthCheck 的 initError 分支加几行独立调用。**
+
+## 改动文件
+
+| 文件 | 改动 |
+|---|---|
+| `components/infiniband/config/check_items.go` | 加 `CheckIBMezzName`、`MezzBoardID` 常量 + `InfinibandCheckItems` 模板项 |
+| `components/infiniband/checker/mezz_name.go` | 新增:`mezzNamingResultAt` + `MezzNamingResult`(默认根)+ `IBMezzNameChecker`/`NewIBMezzNameChecker`/`Name`/`Check` + `^mezz_\d+$` 正则 |
+| `components/infiniband/checker/checker.go` | `checkerConstructors` 加 `config.CheckIBMezzName: NewIBMezzNameChecker` |
+| `components/infiniband/infiniband.go` | `HealthCheck` 的 initError 分支追加 mezz 结果并合并 Status/Level |
+| `components/infiniband/checker/mezz_name_test.go` | 表驱动测试(见下) |
+
+## 测试
+
+`mezzNamingResultAt(t.TempDir())` 造假 sysfs:
+
+- mezz 命名正确(`mezz_0`/`mezz_1`,board_id=NVD79)→ Normal;
+- mezz 命名错误(`mlx5_9`,board_id=NVD79)→ Abnormal / Critical,Device 含 `mlx5_9`;
+- 无 mezz(只有普通 CX7 board_id)→ Normal;
+- 混合(一张对、一张错)→ Abnormal / Critical,只报错的那张;
+- phys_state 映射:`5: LinkUp`→无 `(Down)` 后缀,`2: Polling`→`(Down)`。
+
+## 非目标 / 已知边界
+
+- 不校验 netdev 名(`mezz<k>`),只校验 RDMA 名 `mezz_<k>`(按用户确认)。
+- 不校验 mezz 卡数量(避免"少一张"类误报);只对**已出现**的 mezz 设备判命名。
+- 不修改 `FilterSpec` 的缺-spec 拦截逻辑;mezz 缺 HCA spec 仍会让其它 IB checker 处于 initError,但本检查照常运行。
+- Critical 级别按用户确认;语义上 mezz 命名不符更多是 `rdma-env-pre` 未跑到位的信号,若后续认为 cordon 过重可降 Warning(仅改模板 `Level`)。


### PR DESCRIPTION
Body:
## What
Add an InfiniBand checker `check_ib_mezz_name` that validates every mezz
(internal IB mezzanine) card has its RDMA device named per the `mezz_<k>`
convention. A mismatch means rdma-env-pre's interface-naming did not apply and
is reported **Critical**.

## Why
mezz cards are "identified but not configured" (rdma-env-pre names them
`mezz_0/mezz_1/...` but touches nothing else). If naming silently fails a mezz
device stays at its kernel name (`mlx5_N`); nothing else catches that today.

## How
- **Identity = board_id** (per rdma-env-pre `docs/mezz-card-identification.md`):
  mezz and CX7 share PCI device `0x1021`, so only board_id separates them. The
  board_id is generation-specific, kept as a hardcoded set:
  `NVD0000000079` (B300) + `MT_0000001121` (B200).
- **Spec-free**: reads `/sys/class/infiniband/<dev>/board_id` and the device
  directory name directly — no HCA spec, no heavy collector. This is deliberate:
  the mezz board_id has no HCA spec by design, which otherwise puts the whole IB
  component into `initError` where no normal checker runs. The check therefore
  also runs on the `initError` path (only surfaced there when it actually fails,
  so a passing/no-mezz result is not rendered as a red error).
- Does **not** touch `FilterSpec` / spec-gating.